### PR TITLE
Initial role manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+# OpenZeppelin
+.openzeppelin/dev-*.json
+.openzeppelin/.session
+.openzeppelin/unknown-*.json

--- a/contracts/Permissions/IRoleManager.sol
+++ b/contracts/Permissions/IRoleManager.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface IRoleManager  {
+  
+  /// @dev Determines if the specified address has permission to mint Reaction NFTs
+  /// @param potentialAddress Address to check
+  function isReactionMinter(address potentialAddress) external view returns (bool);
+}

--- a/contracts/Permissions/RoleManager.sol
+++ b/contracts/Permissions/RoleManager.sol
@@ -1,0 +1,22 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "./IRoleManager.sol";
+import "./RoleManagerStorage.sol";
+
+/// @title RoleManager
+/// @dev This contract will track the roles and permissions in the RARA protocol
+contract RoleManager is IRoleManager, AccessControlUpgradeable, RoleManagerStorageV1  {
+  
+  function initialize(address protocolAdmin) public initializer {
+    __AccessControl_init();
+    _setupRole(DEFAULT_ADMIN_ROLE, protocolAdmin);
+  }
+
+  /// @dev Determines if the specified address has permission to mint Reaction NFTs
+  /// @param potentialAddress Address to check
+  function isReactionMinter(address potentialAddress) external view returns (bool) {
+    return hasRole(REACTION_MINTER_ROLE, potentialAddress);
+  }
+}

--- a/contracts/Permissions/RoleManagerStorage.sol
+++ b/contracts/Permissions/RoleManagerStorage.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+/// @title RoleManagerStorage
+/// @dev This contract will hold all local variables for the RoleManager Contract
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the 
+/// StorageManager to inherit from the later version.  This ensures there are no storage layout
+/// corruptions when upgrading.
+contract RoleManagerStorageV1 {
+  bytes32 public constant REACTION_MINTER_ROLE = keccak256("REACTION_MINTER_ROLE");
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract RoleManagerStorageV2 is RoleManagerStorageV1 {
+  address newVariable;
+}
+ */

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
+import "@openzeppelin/hardhat-upgrades";
 
 dotenv.config();
 

--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "ts-node": "^10.1.0",
     "typechain": "^5.1.2",
     "typescript": "^4.5.2"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts-upgradeable": "^4.4.2",
+    "@openzeppelin/hardhat-upgrades": "^1.13.0"
   }
 }

--- a/test/Permissions/RoleManager.ts
+++ b/test/Permissions/RoleManager.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("RoleManager", function () {
+  it("Should set deploying address as owner by default", async function () {
+    const [OWNER, ALICE] = await ethers.getSigners();
+
+    // Deploy the RoleManger using the upgrades plugin with a proxy
+    const RoleManagerFactory = await ethers.getContractFactory("RoleManager");
+    const deployedManager = await upgrades.deployProxy(RoleManagerFactory, [
+      OWNER.address,
+    ]);
+
+    // This attach call is just for typings on the object (not necessary but helpful)
+    const manager = RoleManagerFactory.attach(deployedManager.address);
+
+    const defaultAdminRole = await manager.DEFAULT_ADMIN_ROLE();
+    let result = await manager.hasRole(defaultAdminRole, OWNER.address);
+    expect(result).to.equal(true);
+
+    result = await manager.hasRole(defaultAdminRole, ALICE.address);
+    expect(result).to.equal(false);
+  });
+
+  it("Should allow owner to set Reaction Minter", async function () {
+    // eslint-disable-next-line no-unused-vars
+    const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
+
+    // Deploy the RoleManger using the upgrades plugin with a proxy
+    const RoleManagerFactory = await ethers.getContractFactory("RoleManager");
+    const deployedManager = await upgrades.deployProxy(RoleManagerFactory, [
+      OWNER.address,
+    ]);
+
+    // This attach call is just for typings on the object (not necessary but helpful)
+    const manager = RoleManagerFactory.attach(deployedManager.address);
+
+    const reactionMinterRole = await manager.REACTION_MINTER_ROLE();
+
+    // Verify bob does not haver permission
+    let result = await manager.hasRole(reactionMinterRole, BOB.address);
+    expect(result).to.equal(false);
+
+    // Add BOB
+    await manager.grantRole(reactionMinterRole, BOB.address);
+
+    // Verify it was set
+    result = await manager.isReactionMinter(BOB.address);
+    expect(result).to.equal(true);
+
+    // Verify a non owner (ALICE) can't set the permission
+    await expect(
+      manager.connect(ALICE).grantRole(reactionMinterRole, CAROL.address)
+    ).to.be.reverted;
+
+    // Remove BOB and verify
+    await manager.revokeRole(reactionMinterRole, BOB.address);
+    result = await manager.isReactionMinter(BOB.address);
+    expect(result).to.equal(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,6 +626,33 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.2.tgz#748a5986a02548ef541cabc2ce8c67a890044c40"
+  integrity sha512-bavxs18L47EmcdnL9I6DzsVSUJO+0/zD6zH7/6qG7QRBugvR3VNVZR+nMvuZlCNwuTTnCa3apR00PYzYr/efAw==
+
+"@openzeppelin/hardhat-upgrades@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.13.0.tgz#c2b6a3e0a1694f877b501003b159cf4550452a8b"
+  integrity sha512-0pSSUimzd4JL/mKhdNcczDGhv6ELPcI8cWWyCYjTwKoI3wL+AnRrbIQ+yrpHVpia3dAmI/+1sLOz70HvFKNzNQ==
+  dependencies:
+    "@openzeppelin/upgrades-core" "^1.11.0"
+    chalk "^4.1.0"
+
+"@openzeppelin/upgrades-core@^1.11.0":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.11.1.tgz#fc15ff4b247225fa5cad1ad1495a85612b920913"
+  integrity sha512-CgzE5+/PE8wVHEv5F+PJtE+s2grccM0l8k07yCluSi3qeE+68IK/sv2VLlMYAjsHtJTZyI5WpkwPZK/h3QVhvQ==
+  dependencies:
+    bn.js "^5.1.2"
+    cbor "^8.0.0"
+    chalk "^4.1.0"
+    compare-versions "^4.0.0"
+    debug "^4.1.1"
+    ethereumjs-util "^7.0.3"
+    proper-lockfile "^4.1.1"
+    solidity-ast "^0.4.15"
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"
@@ -2431,6 +2458,13 @@ cbor@^5.0.2:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
 
+cbor@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
+
 chai@^4.2.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
@@ -2464,7 +2498,7 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2692,6 +2726,11 @@ commander@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
+compare-versions@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-4.1.3.tgz#8f7b8966aef7dc4282b45dfa6be98434fc18a1a4"
+  integrity sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -3992,7 +4031,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.2, ethereumjs-util@^7.1.3:
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.2, ethereumjs-util@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.3.tgz#b55d7b64dde3e3e45749e4c41288238edec32d23"
   integrity sha512-y+82tEbyASO0K0X1/SRhbJJoAlfcvq8JbrG4a5cjrOks7HS/36efU/0j2flxCPOUM++HFahk33kr/ZxyC4vNuw==
@@ -4899,7 +4938,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
@@ -6807,6 +6846,11 @@ nofilter@^1.0.4:
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
+
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -7419,6 +7463,15 @@ promise@^8.0.0:
   dependencies:
     asap "~2.0.6"
 
+proper-lockfile@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -7905,6 +7958,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -8372,6 +8430,11 @@ solhint@^3.3.6:
     semver "^6.3.0"
   optionalDependencies:
     prettier "^1.14.3"
+
+solidity-ast@^0.4.15:
+  version "0.4.30"
+  resolved "https://registry.yarnpkg.com/solidity-ast/-/solidity-ast-0.4.30.tgz#402d8277311d6680c786f756ba27e1c19f809293"
+  integrity sha512-3xsQIbZEPx6w7+sQokuOvk1RkMb5GIpuK0GblQDIH6IAkU4+uyJQVJIRNP+8KwhzkViwRKq0hS4zLqQNLKpxOA==
 
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"


### PR DESCRIPTION
Initial contract commit showing how we can set up the repo...
* Contracts inherit from the OpenZeppelin upgradeable contracts.  This requires using initializers instead of constructors.
* Interfaces allow other contracts to call functions in the contract without pulling in too much data, e.g. `IRoleManager`.
* Contracts keep all local variables in separate `storage` contracts to allow upgrading in V2 without worrying about memory layout.  See `RoleManagerStorageV1`
* Unit tests use the Upgrade Hardhat plugin to deploy proxy based contracts in front of an Implementation contract, again to support upgrades.  See `upgrades.deployProxy` in the unit test.