### PR TITLE
Add maker vault and nft registration

### DIFF
--- a/contracts/Config/AddressManager.sol
+++ b/contracts/Config/AddressManager.sol
@@ -1,11 +1,36 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
+import "./IAddressManager.sol";
+import "./AddressManagerStorage.sol";
 
-contract AddressManager {
-    address public makerVault;
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-    function setMakerVault(address newMakerVault) external {
-      makerVault = newMakerVault;
+contract AddressManager is
+    IAddressManager,
+    Initializable,
+    AddressManagerStorageV1
+{
+    /// @dev Verifies with the role manager that the calling address has ADMIN role
+    modifier onlyAdmin() {
+        require(roleManager.isAdmin(msg.sender), "Not Admin");
+        _;
+    }
+
+    /// @dev initializer to call after deployment, can only be called once
+    function initialize(IRoleManager _roleManager) public initializer {
+        require(address(_roleManager) != address(0x0), "Invalid _roleManager");
+        roleManager = _roleManager;
+    }
+
+    /// @dev Getter for the role manager address
+    function getRoleManager() external view returns (IRoleManager) {
+        return roleManager;
+    }
+
+    /// @dev Setter for the role manager address
+    function setRoleManager(IRoleManager _roleManager) external onlyAdmin {
+        require(address(_roleManager) != address(0x0), "Invalid _roleManager");
+        roleManager = _roleManager;
     }
 }

--- a/contracts/Config/AddressManagerStorage.sol
+++ b/contracts/Config/AddressManagerStorage.sol
@@ -1,0 +1,22 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../Permissions/IRoleManager.sol";
+
+/// @title AddressManagerStorage
+/// @dev This contract will hold all local variables for the AddressManager Contract
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the
+/// AddressManager to inherit from the later version.  This ensures there are no storage layout
+/// corruptions when upgrading.
+contract AddressManagerStorageV1 {
+    /// @dev Local reference to the role manager contract
+    IRoleManager public roleManager;
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract AddressManagerStorageV2 is AddressManagerStorageV1 {
+  address newVariable;
+}
+ */

--- a/contracts/Config/IAddressManager.sol
+++ b/contracts/Config/IAddressManager.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../Permissions/IRoleManager.sol";
+
+interface IAddressManager {
+    /// @dev Getter for the role manager address
+    function getRoleManager() external returns (IRoleManager);
+
+    /// @dev Setter for the role manager address
+    function setRoleManager(IRoleManager _roleManager) external;
+}

--- a/contracts/Maker/IMakerVault.sol
+++ b/contracts/Maker/IMakerVault.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+/// @dev Interface for the maker vault that supports registering and de-registering NFTs
+interface IMakerVault {
+    /// @dev struct for storing details about a registered NFT
+    struct NftDetails {
+        bool registered;
+        address owner;
+        address creator;
+    }
+}

--- a/contracts/Maker/MakerVault.sol
+++ b/contracts/Maker/MakerVault.sol
@@ -1,0 +1,92 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
+import "../Permissions/IRoleManager.sol";
+import "./IMakerVault.sol";
+import "./MakerVaultStorage.sol";
+
+/// @title MakerVault
+/// @dev This contract tracks registered NFTs.  Owners of an NFT can register
+/// and de-register any NFTs owned in their wallet.
+/// Also, for the mappings, it is assumed the protocol will always look up the current owner of
+/// an NFT when running logic (which is why the owner address is not stored).  If desired, an
+/// off-chain indexer like The Graph can index registration addresses to NFTs.
+contract MakerVault is IMakerVault, Initializable, MakerVaultStorageV1 {
+    /// @dev Event triggered when an NFT is registered in the system
+    event Registered(
+        address indexed nftContractAddress,
+        uint256 indexed nftID,
+        address indexed ownerAddress,
+        address creatorAddress,
+        uint256 optionBits,
+        uint256 sourceId,
+        uint256 metaId
+    );
+
+    /// @dev initializer to call after deployment, can only be called once
+    function initialize(IAddressManager _addressManager) public initializer {
+        addressManager = _addressManager;
+    }
+
+    /// @dev Allows a NFT owner to register the NFT in the protocol.
+    /// Owner registering must own the NFT in the wallet calling function.
+    function registerNFT(
+        address nftContractAddress,
+        uint256 nftID,
+        address creatorAddress,
+        uint256 optionBits
+    ) external {
+        // Verify ownership
+        // TODO: support ERC721 + other custom contracts
+        uint256 balance = IERC1155Upgradeable(nftContractAddress).balanceOf(
+            msg.sender,
+            nftID
+        );
+        require(balance > 0, "NFT not owned");
+
+        // TODO: Block registration of a RaRa reaction NFT once Reaction Vault is built out
+
+        // Look up the source ID
+        uint256 currentSourceId = nftToSourceLookup[nftContractAddress][nftID];
+
+        // Check to see if the source ID is already set for this NFT
+        if (currentSourceId > 0) {
+            // If it is already in the system, verify it is not currently registered
+            NftDetails memory currentDetails = sourceToDetailsLookup[
+                currentSourceId
+            ];
+            require(!currentDetails.registered, "Already registered");
+        } else {
+            // If not already in the system, increment the source ID to use
+            currentSourceId = ++sourceCount;
+        }
+
+        // Generate Meta ID
+        uint256 metaId = uint256(
+            keccak256(abi.encode(META_PREFIX, currentSourceId, optionBits))
+        );
+
+        // Register in mappings
+        nftToSourceLookup[nftContractAddress][nftID] = currentSourceId;
+        metaToSourceLookup[metaId] = currentSourceId;
+        sourceToDetailsLookup[currentSourceId] = NftDetails(
+            true,
+            msg.sender,
+            creatorAddress
+        );
+
+        // Emit event
+        emit Registered(
+            nftContractAddress,
+            nftID,
+            msg.sender,
+            creatorAddress,
+            optionBits,
+            currentSourceId,
+            metaId
+        );
+    }
+}

--- a/contracts/Maker/MakerVaultStorage.sol
+++ b/contracts/Maker/MakerVaultStorage.sol
@@ -1,0 +1,39 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../Config/IAddressManager.sol";
+import "./IMakerVault.sol";
+
+/// @title MakerVaultStorage
+/// @dev This contract will hold all local variables for the MakerVault Contract
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the
+/// MakerVault to inherit from the later version.  This ensures there are no storage layout
+/// corruptions when upgrading.
+contract MakerVaultStorageV1 {
+    /// @dev local reference to the address manager contract
+    IAddressManager public addressManager;
+
+    /// @dev prefix used in meta ID generation
+    string public constant META_PREFIX = "MAKER";
+
+    /// @dev An incrementing unique number assigned to each NFT that is registered.
+    /// De-registering and re-registering should use the existing source ID
+    uint256 public sourceCount;
+
+    /// @dev Mapping to look up source ID from NFT address and ID
+    mapping(address => mapping(uint256 => uint256)) public nftToSourceLookup;
+
+    /// @dev Mapping to look up source ID from meta ID key
+    mapping(uint256 => uint256) public metaToSourceLookup;
+
+    /// @dev Mapping to look up nft details from source ID
+    mapping(uint256 => IMakerVault.NftDetails) public sourceToDetailsLookup;
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract MakerVaultStorageV2 is MakerVaultStorageV1 {
+  address newVariable;
+}
+ */

--- a/contracts/Permissions/IRoleManager.sol
+++ b/contracts/Permissions/IRoleManager.sol
@@ -1,9 +1,22 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-interface IRoleManager  {
-  
-  /// @dev Determines if the specified address has permission to mint Reaction NFTs
-  /// @param potentialAddress Address to check
-  function isReactionMinter(address potentialAddress) external view returns (bool);
+interface IRoleManager {
+    /// @dev Determines if the specified address has permission to mint Reaction NFTs
+    /// @param potentialAddress Address to check
+    function isReactionMinter(address potentialAddress)
+        external
+        view
+        returns (bool);
+
+    /// @dev Determines if the specified address has permission to burn Reaction NFTs
+    /// @param potentialAddress Address to check
+    function isReactionBurner(address potentialAddress)
+        external
+        view
+        returns (bool);
+
+    /// @dev Determines if the specified address is an admin account
+    /// @param potentialAddress Address to check
+    function isAdmin(address potentialAddress) external view returns (bool);
 }

--- a/contracts/Permissions/RoleManager.sol
+++ b/contracts/Permissions/RoleManager.sol
@@ -7,16 +7,40 @@ import "./RoleManagerStorage.sol";
 
 /// @title RoleManager
 /// @dev This contract will track the roles and permissions in the RARA protocol
-contract RoleManager is IRoleManager, AccessControlUpgradeable, RoleManagerStorageV1  {
-  
-  function initialize(address protocolAdmin) public initializer {
-    __AccessControl_init();
-    _setupRole(DEFAULT_ADMIN_ROLE, protocolAdmin);
-  }
+contract RoleManager is
+    IRoleManager,
+    AccessControlUpgradeable,
+    RoleManagerStorageV1
+{
+    /// @dev initializer to call after deployment, can only be called once
+    function initialize(address protocolAdmin) public initializer {
+        __AccessControl_init();
+        _setupRole(DEFAULT_ADMIN_ROLE, protocolAdmin);
+    }
 
-  /// @dev Determines if the specified address has permission to mint Reaction NFTs
-  /// @param potentialAddress Address to check
-  function isReactionMinter(address potentialAddress) external view returns (bool) {
-    return hasRole(REACTION_MINTER_ROLE, potentialAddress);
-  }
+    /// @dev Determines if the specified address is the owner account
+    /// @param potentialAddress Address to check
+    function isAdmin(address potentialAddress) external view returns (bool) {
+        return hasRole(DEFAULT_ADMIN_ROLE, potentialAddress);
+    }
+
+    /// @dev Determines if the specified address has permission to mint Reaction NFTs
+    /// @param potentialAddress Address to check
+    function isReactionMinter(address potentialAddress)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(REACTION_MINTER_ROLE, potentialAddress);
+    }
+
+    /// @dev Determines if the specified address has permission to burn Reaction NFTs
+    /// @param potentialAddress Address to check
+    function isReactionBurner(address potentialAddress)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(REACTION_BURNER_ROLE, potentialAddress);
+    }
 }

--- a/contracts/Permissions/RoleManagerStorage.sol
+++ b/contracts/Permissions/RoleManagerStorage.sol
@@ -3,11 +3,17 @@ pragma solidity 0.8.9;
 
 /// @title RoleManagerStorage
 /// @dev This contract will hold all local variables for the RoleManager Contract
-/// When upgrading the protocol, inherit from this contract on the V2 version and change the 
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the
 /// StorageManager to inherit from the later version.  This ensures there are no storage layout
 /// corruptions when upgrading.
 contract RoleManagerStorageV1 {
-  bytes32 public constant REACTION_MINTER_ROLE = keccak256("REACTION_MINTER_ROLE");
+    /// @dev role for granting capability to mint reactions
+    bytes32 public constant REACTION_MINTER_ROLE =
+        keccak256("REACTION_MINTER_ROLE");
+
+    /// @dev role for granting capability to burn reactions
+    bytes32 public constant REACTION_BURNER_ROLE =
+        keccak256("REACTION_BURNER_ROLE");
 }
 
 /// On the next version of the protocol, if new variables are added, put them in the below

--- a/contracts/Token/IStandard1155.sol
+++ b/contracts/Token/IStandard1155.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+/// @dev Interface for the Standard1155 toke contract.
+interface IStandard1155 {
+    /// @dev Allows a priviledged account to mint tokens to the specified address
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external;
+}

--- a/contracts/Token/Standard1155.sol
+++ b/contracts/Token/Standard1155.sol
@@ -1,0 +1,44 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import "../Permissions/IRoleManager.sol";
+import "./IStandard1155.sol";
+import "./Standard1155Storage.sol";
+
+/// @title Standard1155
+/// @dev This contract implements the 1155 standard
+contract Standard1155 is
+    IStandard1155,
+    ERC1155Upgradeable,
+    Standard1155StorageV1
+{
+    /// @dev verifies that the calling account has a role to enable minting tokens
+    modifier onlyMinter() {
+        IRoleManager roleManager = IRoleManager(
+            addressManager.getRoleManager()
+        );
+        require(roleManager.isReactionMinter(msg.sender), "Not Minter");
+        _;
+    }
+
+    /// @dev initializer to call after deployment, can only be called once
+    function initialize(string memory _uri, address _addressManager)
+        public
+        initializer
+    {
+        __ERC1155_init(_uri);
+
+        addressManager = IAddressManager(_addressManager);
+    }
+
+    /// @dev Allows a priviledged account to mint tokens to the specified address
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external onlyMinter {
+        _mint(to, id, amount, data);
+    }
+}

--- a/contracts/Token/Standard1155Storage.sol
+++ b/contracts/Token/Standard1155Storage.sol
@@ -1,0 +1,21 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../Config/IAddressManager.sol";
+
+/// @title Standard1155StorageV1
+/// @dev This contract will hold all local variables for the Standard1155 Contract
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the
+/// Standard1155 to inherit from the later version.  This ensures there are no storage layout
+/// corruptions when upgrading.
+contract Standard1155StorageV1 {
+    IAddressManager public addressManager;
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract Standard1155StorageV2 is Standard1155StorageV1 {
+  address newVariable;
+}
+ */

--- a/test/Maker/MakerVault.ts
+++ b/test/Maker/MakerVault.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { ZERO_ADDRESS } from "../Scripts/constants";
+import { deploySystem } from "../Scripts/deploy";
+import { ALREADY_REGISTERED, NFT_NOT_OWNED } from "../Scripts/errors";
+
+describe("MakerVault", function () {
+  it("Should get initialized with address manager", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { makerVault, addressManager } = await deploySystem(OWNER);
+
+    // Verify the address manager was set
+    const currentAddressManager = await makerVault.addressManager();
+    expect(currentAddressManager).to.equal(addressManager.address);
+  });
+
+  it("Should verify NFT ownership", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { makerVault, testingStandard1155 } = await deploySystem(OWNER);
+
+    // Since this is trying to register a non-existing NFT it should show the caller doesn't own it
+    await expect(
+      makerVault.registerNFT(
+        testingStandard1155.address,
+        "1",
+        ZERO_ADDRESS,
+        "0"
+      )
+    ).to.revertedWith(NFT_NOT_OWNED);
+  });
+
+  it("Should allow NFT registration only once", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { makerVault, roleManager, testingStandard1155 } = await deploySystem(
+      OWNER
+    );
+
+    // Mint an NFT to Alice
+    const NFT_ID = "1";
+    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
+    roleManager.grantRole(reactionMinterRole, OWNER.address);
+    testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
+
+    // Register the NFT from Alice's account and put Bob as the creator
+    // Verify event as well
+    await makerVault
+      .connect(ALICE)
+      .registerNFT(testingStandard1155.address, NFT_ID, BOB.address, "0");
+
+    // Verify it can't be registered again now that it is registered
+    await expect(
+      makerVault
+        .connect(ALICE)
+        .registerNFT(testingStandard1155.address, NFT_ID, BOB.address, "0")
+    ).to.revertedWith(ALREADY_REGISTERED);
+  });
+
+  it("Should emit registration event and verify mappings", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { makerVault, roleManager, testingStandard1155 } = await deploySystem(
+      OWNER
+    );
+
+    // Mint an NFT to Alice
+    const NFT_ID = "1";
+    const OPTION_BITS = "0";
+    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
+    roleManager.grantRole(reactionMinterRole, OWNER.address);
+    testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
+
+    // Encode the params and hash it to get the meta URI
+    const encodedParams = ethers.utils.defaultAbiCoder.encode(
+      ["string", "uint256", "uint256"],
+      ["MAKER", 1, 0]
+    );
+    const derivedMetaId = ethers.utils.keccak256(encodedParams);
+
+    // First one registered should have source ID 1
+    const EXPECTED_SOURCE_ID = "1";
+
+    // Register the NFT from Alice's account and put Bob as the creator
+    // Verify event as well
+    await expect(
+      makerVault
+        .connect(ALICE)
+        .registerNFT(
+          testingStandard1155.address,
+          NFT_ID,
+          BOB.address,
+          OPTION_BITS
+        )
+    )
+      .to.emit(makerVault, "Registered")
+      .withArgs(
+        testingStandard1155.address,
+        BigNumber.from(NFT_ID),
+        ALICE.address,
+        BOB.address,
+        BigNumber.from(OPTION_BITS),
+        BigNumber.from(EXPECTED_SOURCE_ID),
+        derivedMetaId
+      );
+
+    // Verify lookups are set in the mapping
+    // Verify source id from nft param
+    expect(
+      await makerVault.nftToSourceLookup(testingStandard1155.address, NFT_ID)
+    ).to.equal(EXPECTED_SOURCE_ID);
+
+    // Verify source from meta id
+    expect(await makerVault.metaToSourceLookup(derivedMetaId)).to.equal(
+      EXPECTED_SOURCE_ID
+    );
+
+    // Verify registration details from source id
+    const [registered, owner, creator] = await makerVault.sourceToDetailsLookup(
+      BigNumber.from(EXPECTED_SOURCE_ID)
+    );
+    expect(registered).to.equal(true);
+    expect(owner).to.equal(ALICE.address);
+    expect(creator).to.equal(BOB.address);
+  });
+});

--- a/test/Scripts/constants.ts
+++ b/test/Scripts/constants.ts
@@ -1,0 +1,4 @@
+const TEST_NFT_URI = "https://rara.social/test-nfts/{id}.json";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export { TEST_NFT_URI, ZERO_ADDRESS };

--- a/test/Scripts/deploy.ts
+++ b/test/Scripts/deploy.ts
@@ -1,0 +1,53 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers, upgrades } from "hardhat";
+import { TEST_NFT_URI } from "./constants";
+
+const deploySystem = async (owner: SignerWithAddress) => {
+  // Deploy the Role Manager first
+  const RoleManagerFactory = await ethers.getContractFactory("RoleManager");
+  const deployedRoleManager = await upgrades.deployProxy(RoleManagerFactory, [
+    owner.address,
+  ]);
+  const roleManager = RoleManagerFactory.attach(deployedRoleManager.address);
+
+  // Deploy Address Manager
+  const AddressManagerFactory = await ethers.getContractFactory(
+    "AddressManager"
+  );
+  const deployedAddressManager = await upgrades.deployProxy(
+    AddressManagerFactory,
+    [roleManager.address]
+  );
+  const addressManager = AddressManagerFactory.attach(
+    deployedAddressManager.address
+  );
+
+  // Deploy Maker Vault
+  const MakerVaultFactory = await ethers.getContractFactory("MakerVault");
+  const deployedMakerVault = await upgrades.deployProxy(MakerVaultFactory, [
+    addressManager.address,
+  ]);
+  const makerVault = MakerVaultFactory.attach(deployedMakerVault.address);
+
+  // Deploy Testing NFT Token 1155
+  // NOTE: We are not granting any default permissions for minting in the role manager to the owner
+  // because the tests of the protocol should not assume any roles are granted for external accounts.
+  const Standard1155Factory = await ethers.getContractFactory("Standard1155");
+  const deployedStandard1155 = await upgrades.deployProxy(Standard1155Factory, [
+    TEST_NFT_URI,
+    addressManager.address,
+  ]);
+  const testingStandard1155 = Standard1155Factory.attach(
+    deployedStandard1155.address
+  );
+
+  // Return objects for tests to use
+  return {
+    roleManager,
+    addressManager,
+    makerVault,
+    testingStandard1155,
+  };
+};
+
+export { deploySystem };

--- a/test/Scripts/errors.ts
+++ b/test/Scripts/errors.ts
@@ -1,0 +1,4 @@
+const NFT_NOT_OWNED = "NFT not owned";
+const ALREADY_REGISTERED = "Already registered";
+
+export { NFT_NOT_OWNED, ALREADY_REGISTERED };

--- a/test/Token/Standard1155.ts
+++ b/test/Token/Standard1155.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deploySystem } from "../Scripts/deploy";
+import { TEST_NFT_URI } from "../Scripts/constants";
+
+describe("Standard1155 Token", function () {
+  it("Should get initialized with address manager", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { testingStandard1155, addressManager } = await deploySystem(OWNER);
+
+    // Verify the address manager and uri are set
+    const setURI = await testingStandard1155.uri(1);
+    expect(setURI).to.equal(TEST_NFT_URI);
+
+    const setAddrssManager = await testingStandard1155.addressManager();
+    expect(setAddrssManager).to.equal(addressManager.address);
+  });
+
+  it("Should mint tokens if authorized", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { testingStandard1155, roleManager } = await deploySystem(OWNER);
+
+    // Verify Bob's non-authorized acct can't mint
+    await expect(
+      testingStandard1155.connect(BOB).mint(ALICE.address, "1", "1000", [0])
+    ).to.be.reverted;
+
+    // Grant authorization to Bob
+    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
+    roleManager.grantRole(reactionMinterRole, BOB.address);
+
+    // Mint again
+    testingStandard1155.connect(BOB).mint(ALICE.address, "1", "1000", [0]);
+
+    // Verify balance
+    let balance = await testingStandard1155.balanceOf(ALICE.address, "1");
+    expect(balance.toString()).to.equal("1000");
+
+    // Verify transfer
+    await testingStandard1155
+      .connect(ALICE)
+      .safeTransferFrom(ALICE.address, BOB.address, "1", "250", [0]);
+
+    // Verify Bob balance
+    balance = await testingStandard1155.balanceOf(BOB.address, "1");
+    expect(balance.toString()).to.equal("250");
+  });
+});


### PR DESCRIPTION
This PR targets the initial stab at registering NFTs.

Token/Standard1155.sol
* In order to test NFT registration we needed a token contract to simulate ownership in the unit tests.
* When we start minting Reaction NFTs, we will need a token contract to track them as well.
* This contract utilizes the RoleManager to gate minting/burning

Maker/MakerVault.sol
* This contract will track registrations (and soon, de-registrations).
* It will verify ownership of an NFT and register it to the system
* It will assign and store Source ID, Meta ID, and Creator address associated with the NFT.
* It will trigger an event to be indexed off chain

Mappings were created in the Maker Vault to track the linkage between NFT Address + ID, Source ID, and Meta ID.  The unit tests verify the logic, error scenarios, and event emission.

There are a couple of TODOs in the register function that can be fixed in a later PR, but wanted to get this one reviewed while it's hot.

Also, check out the helper functions under the test/scripts folder.  Specifically the deploy.ts file can be used by unit tests to deploy the protocol so each test doesn't need to worry about it.