### PR TITLE
Curation Vault buying/selling shares

### DIFF
--- a/contracts/Config/AddressManager.sol
+++ b/contracts/Config/AddressManager.sol
@@ -58,4 +58,22 @@ contract AddressManager is Initializable, AddressManagerStorageV1 {
         require(address(_reactionNftContract) != address(0x0), ZERO_INPUT);
         reactionNftContract = _reactionNftContract;
     }
+
+    /// @dev Setter for the maker registrar address
+    function setReactionVault(IReactionVault _reactionVault)
+        external
+        onlyAdmin
+    {
+        require(address(_reactionVault) != address(0x0), ZERO_INPUT);
+        reactionVault = _reactionVault;
+    }
+
+    /// @dev Setter for the default curator vault address
+    function setDefaultCuratorVault(IPermanentCuratorVault _defaultCuratorVault)
+        external
+        onlyAdmin
+    {
+        require(address(_defaultCuratorVault) != address(0x0), ZERO_INPUT);
+        defaultCuratorVault = _defaultCuratorVault;
+    }
 }

--- a/contracts/Config/AddressManagerStorage.sol
+++ b/contracts/Config/AddressManagerStorage.sol
@@ -27,6 +27,12 @@ abstract contract AddressManagerStorageV1 is IAddressManager {
 
     /// @dev Local reference to the reaction NFT contract
     IStandard1155 public reactionNftContract;
+
+    /// @dev Local reference to the reaction vault
+    IReactionVault public reactionVault;
+
+    /// @dev Local reference to the default curator vault
+    IPermanentCuratorVault public defaultCuratorVault;
 }
 
 /// On the next version of the protocol, if new variables are added, put them in the below

--- a/contracts/Config/IAddressManager.sol
+++ b/contracts/Config/IAddressManager.sol
@@ -5,6 +5,8 @@ import "../Permissions/IRoleManager.sol";
 import "../Parameters/IParameterManager.sol";
 import "../Maker/IMakerRegistrar.sol";
 import "../Token/IStandard1155.sol";
+import "../Reactions/IReactionVault.sol";
+import "../PermanentCuratorVault/IPermanentCuratorVault.sol";
 
 interface IAddressManager {
     /// @dev Getter for the role manager address
@@ -30,5 +32,18 @@ interface IAddressManager {
 
     /// @dev Setter for the reaction NFT contract address
     function setReactionNftContract(IStandard1155 _reactionNftContract)
+        external;
+
+    /// @dev Getter for the reaction Vault contract address
+    function reactionVault() external returns (IReactionVault);
+
+    /// @dev Setter for the reaction Vault contract address
+    function setReactionVault(IReactionVault _reactionVault) external;
+
+    /// @dev Getter for the default Curator Vault contract address
+    function defaultCuratorVault() external returns (IPermanentCuratorVault);
+
+    /// @dev Setter for the default Curator Vault contract address
+    function setDefaultCuratorVault(IPermanentCuratorVault _defaultCuratorVault)
         external;
 }

--- a/contracts/PermanentCuratorVault/Curve/BancorFormula.sol
+++ b/contracts/PermanentCuratorVault/Curve/BancorFormula.sol
@@ -1,0 +1,120 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
+import "./Power.sol"; // Efficient power function.
+
+/**
+ * @title Bancor formula by Bancor
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements;
+ * and to You under the Apache License, Version 2.0. "
+ */
+contract BancorFormula is Power {
+    using SafeMathUpgradeable for uint256;
+    uint32 private constant MAX_RESERVE_RATIO = 1000000;
+
+    /**
+     * @dev given a continuous token supply, reserve token balance, reserve ratio, and a deposit amount (in the reserve token),
+     * calculates the return for a given conversion (in the continuous token)
+     *
+     * Formula:
+     * Return = _supply * ((1 + _depositAmount / _reserveBalance) ^ (_reserveRatio / MAX_RESERVE_RATIO) - 1)
+     *
+     * @param _supply              continuous token total supply
+     * @param _reserveBalance    total reserve token balance
+     * @param _reserveRatio     reserve ratio, represented in ppm, 1-1000000
+     * @param _depositAmount       deposit amount, in reserve token
+     *
+     *  @return purchase return amount
+     */
+    function calculatePurchaseReturn(
+        uint256 _supply,
+        uint256 _reserveBalance,
+        uint32 _reserveRatio,
+        uint256 _depositAmount
+    ) public view returns (uint256) {
+        // validate input
+        require(
+            _supply > 0 &&
+                _reserveBalance > 0 &&
+                _reserveRatio > 0 &&
+                _reserveRatio <= MAX_RESERVE_RATIO,
+            "Invalid inputs."
+        );
+        // special case for 0 deposit amount
+        if (_depositAmount == 0) {
+            return 0;
+        }
+        // special case if the ratio = 100%
+        if (_reserveRatio == MAX_RESERVE_RATIO) {
+            return _supply.mul(_depositAmount).div(_reserveBalance);
+        }
+        uint256 result;
+        uint8 precision;
+        uint256 baseN = _depositAmount.add(_reserveBalance);
+        (result, precision) = power(
+            baseN,
+            _reserveBalance,
+            _reserveRatio,
+            MAX_RESERVE_RATIO
+        );
+        uint256 newTokenSupply = _supply.mul(result) >> precision;
+        return newTokenSupply.sub(_supply);
+    }
+
+    /**
+     * @dev given a continuous token supply, reserve token balance, reserve ratio and a sell amount (in the continuous token),
+     * calculates the return for a given conversion (in the reserve token)
+     *
+     * Formula:
+     * Return = _reserveBalance * (1 - (1 - _sellAmount / _supply) ^ (1 / (_reserveRatio / MAX_RESERVE_RATIO)))
+     *
+     * @param _supply              continuous token total supply
+     * @param _reserveBalance    total reserve token balance
+     * @param _reserveRatio     constant reserve ratio, represented in ppm, 1-1000000
+     * @param _sellAmount          sell amount, in the continuous token itself
+     *
+     * @return sale return amount
+     */
+    function calculateSaleReturn(
+        uint256 _supply,
+        uint256 _reserveBalance,
+        uint32 _reserveRatio,
+        uint256 _sellAmount
+    ) public view returns (uint256) {
+        // validate input
+        require(
+            _supply > 0 &&
+                _reserveBalance > 0 &&
+                _reserveRatio > 0 &&
+                _reserveRatio <= MAX_RESERVE_RATIO &&
+                _sellAmount <= _supply,
+            "Invalid inputs."
+        );
+        // special case for 0 sell amount
+        if (_sellAmount == 0) {
+            return 0;
+        }
+        // special case for selling the entire supply
+        if (_sellAmount == _supply) {
+            return _reserveBalance;
+        }
+        // special case if the ratio = 100%
+        if (_reserveRatio == MAX_RESERVE_RATIO) {
+            return _reserveBalance.mul(_sellAmount).div(_supply);
+        }
+        uint256 result;
+        uint8 precision;
+        uint256 baseD = _supply.sub(_sellAmount);
+        (result, precision) = power(
+            _supply,
+            baseD,
+            MAX_RESERVE_RATIO,
+            _reserveRatio
+        );
+        uint256 oldBalance = _reserveBalance.mul(result);
+        uint256 newBalance = _reserveBalance << precision;
+        return oldBalance.sub(newBalance).div(result);
+    }
+}

--- a/contracts/PermanentCuratorVault/Curve/Power.sol
+++ b/contracts/PermanentCuratorVault/Curve/Power.sol
@@ -1,0 +1,566 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @title Power function by Bancor
+ * @dev https://github.com/bancorprotocol/contracts
+ *
+ * Modified from the original by Slava Balasanov & Tarrence van As
+ *
+ * Split Power.sol out from BancorFormula.sol
+ * https://github.com/bancorprotocol/contracts/blob/c9adc95e82fdfb3a0ada102514beb8ae00147f5d/solidity/contracts/converter/BancorFormula.sol
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements;
+ * and to You under the Apache License, VERSION 2.0. "
+ */
+contract Power is Initializable {
+    string public constant VERSION = "0.3";
+
+    uint256 private constant ONE = 1;
+    uint32 private constant MAX_WEIGHT = 1000000;
+    uint8 private constant MIN_PRECISION = 32;
+    uint8 private constant MAX_PRECISION = 127;
+
+    /**
+      The values below depend on MAX_PRECISION. If you choose to change it:
+      Apply the same change in file 'PrintIntScalingFactors.py', run it and paste the results below.
+    */
+    uint256 private constant FIXED_1 = 0x080000000000000000000000000000000;
+    uint256 private constant FIXED_2 = 0x100000000000000000000000000000000;
+    uint256 private constant MAX_NUM = 0x200000000000000000000000000000000;
+
+    /**
+        Auto-generated via 'PrintLn2ScalingFactors.py'
+    */
+    uint256 private constant LN2_NUMERATOR = 0x3f80fe03f80fe03f80fe03f80fe03f8;
+    uint256 private constant LN2_DENOMINATOR =
+        0x5b9de1d10bf4103d647b0955897ba80;
+
+    /**
+        Auto-generated via 'PrintFunctionOptimalLog.py' and 'PrintFunctionOptimalExp.py'
+    */
+    uint256 private constant OPT_LOG_MAX_VAL =
+        0x15bf0a8b1457695355fb8ac404e7a79e3;
+    uint256 private constant OPT_EXP_MAX_VAL =
+        0x800000000000000000000000000000000;
+
+    /**
+      The values below depend on MIN_PRECISION and MAX_PRECISION. If you choose to change either one of them:
+      Apply the same change in file 'PrintFunctionBancorFormula.py', run it and paste the results below.
+    */
+    uint256[128] private maxExpArray;
+
+    function __Power_init() internal onlyInitializing {
+        //  maxExpArray[0] = 0x6bffffffffffffffffffffffffffffffff;
+        //  maxExpArray[1] = 0x67ffffffffffffffffffffffffffffffff;
+        //  maxExpArray[2] = 0x637fffffffffffffffffffffffffffffff;
+        //  maxExpArray[3] = 0x5f6fffffffffffffffffffffffffffffff;
+        //  maxExpArray[4] = 0x5b77ffffffffffffffffffffffffffffff;
+        //  maxExpArray[5] = 0x57b3ffffffffffffffffffffffffffffff;
+        //  maxExpArray[6] = 0x5419ffffffffffffffffffffffffffffff;
+        //  maxExpArray[7] = 0x50a2ffffffffffffffffffffffffffffff;
+        //  maxExpArray[8] = 0x4d517fffffffffffffffffffffffffffff;
+        //  maxExpArray[9] = 0x4a233fffffffffffffffffffffffffffff;
+        //  maxExpArray[10] = 0x47165fffffffffffffffffffffffffffff;
+        //  maxExpArray[11] = 0x4429afffffffffffffffffffffffffffff;
+        //  maxExpArray[12] = 0x415bc7ffffffffffffffffffffffffffff;
+        //  maxExpArray[13] = 0x3eab73ffffffffffffffffffffffffffff;
+        //  maxExpArray[14] = 0x3c1771ffffffffffffffffffffffffffff;
+        //  maxExpArray[15] = 0x399e96ffffffffffffffffffffffffffff;
+        //  maxExpArray[16] = 0x373fc47fffffffffffffffffffffffffff;
+        //  maxExpArray[17] = 0x34f9e8ffffffffffffffffffffffffffff;
+        //  maxExpArray[18] = 0x32cbfd5fffffffffffffffffffffffffff;
+        //  maxExpArray[19] = 0x30b5057fffffffffffffffffffffffffff;
+        //  maxExpArray[20] = 0x2eb40f9fffffffffffffffffffffffffff;
+        //  maxExpArray[21] = 0x2cc8340fffffffffffffffffffffffffff;
+        //  maxExpArray[22] = 0x2af09481ffffffffffffffffffffffffff;
+        //  maxExpArray[23] = 0x292c5bddffffffffffffffffffffffffff;
+        //  maxExpArray[24] = 0x277abdcdffffffffffffffffffffffffff;
+        //  maxExpArray[25] = 0x25daf6657fffffffffffffffffffffffff;
+        //  maxExpArray[26] = 0x244c49c65fffffffffffffffffffffffff;
+        //  maxExpArray[27] = 0x22ce03cd5fffffffffffffffffffffffff;
+        //  maxExpArray[28] = 0x215f77c047ffffffffffffffffffffffff;
+        //  maxExpArray[29] = 0x1fffffffffffffffffffffffffffffffff;
+        //  maxExpArray[30] = 0x1eaefdbdabffffffffffffffffffffffff;
+        //  maxExpArray[31] = 0x1d6bd8b2ebffffffffffffffffffffffff;
+        maxExpArray[32] = 0x1c35fedd14ffffffffffffffffffffffff;
+        maxExpArray[33] = 0x1b0ce43b323fffffffffffffffffffffff;
+        maxExpArray[34] = 0x19f0028ec1ffffffffffffffffffffffff;
+        maxExpArray[35] = 0x18ded91f0e7fffffffffffffffffffffff;
+        maxExpArray[36] = 0x17d8ec7f0417ffffffffffffffffffffff;
+        maxExpArray[37] = 0x16ddc6556cdbffffffffffffffffffffff;
+        maxExpArray[38] = 0x15ecf52776a1ffffffffffffffffffffff;
+        maxExpArray[39] = 0x15060c256cb2ffffffffffffffffffffff;
+        maxExpArray[40] = 0x1428a2f98d72ffffffffffffffffffffff;
+        maxExpArray[41] = 0x13545598e5c23fffffffffffffffffffff;
+        maxExpArray[42] = 0x1288c4161ce1dfffffffffffffffffffff;
+        maxExpArray[43] = 0x11c592761c666fffffffffffffffffffff;
+        maxExpArray[44] = 0x110a688680a757ffffffffffffffffffff;
+        maxExpArray[45] = 0x1056f1b5bedf77ffffffffffffffffffff;
+        maxExpArray[46] = 0x0faadceceeff8bffffffffffffffffffff;
+        maxExpArray[47] = 0x0f05dc6b27edadffffffffffffffffffff;
+        maxExpArray[48] = 0x0e67a5a25da4107fffffffffffffffffff;
+        maxExpArray[49] = 0x0dcff115b14eedffffffffffffffffffff;
+        maxExpArray[50] = 0x0d3e7a392431239fffffffffffffffffff;
+        maxExpArray[51] = 0x0cb2ff529eb71e4fffffffffffffffffff;
+        maxExpArray[52] = 0x0c2d415c3db974afffffffffffffffffff;
+        maxExpArray[53] = 0x0bad03e7d883f69bffffffffffffffffff;
+        maxExpArray[54] = 0x0b320d03b2c343d5ffffffffffffffffff;
+        maxExpArray[55] = 0x0abc25204e02828dffffffffffffffffff;
+        maxExpArray[56] = 0x0a4b16f74ee4bb207fffffffffffffffff;
+        maxExpArray[57] = 0x09deaf736ac1f569ffffffffffffffffff;
+        maxExpArray[58] = 0x0976bd9952c7aa957fffffffffffffffff;
+        maxExpArray[59] = 0x09131271922eaa606fffffffffffffffff;
+        maxExpArray[60] = 0x08b380f3558668c46fffffffffffffffff;
+        maxExpArray[61] = 0x0857ddf0117efa215bffffffffffffffff;
+        maxExpArray[62] = 0x07ffffffffffffffffffffffffffffffff;
+        maxExpArray[63] = 0x07abbf6f6abb9d087fffffffffffffffff;
+        maxExpArray[64] = 0x075af62cbac95f7dfa7fffffffffffffff;
+        maxExpArray[65] = 0x070d7fb7452e187ac13fffffffffffffff;
+        maxExpArray[66] = 0x06c3390ecc8af379295fffffffffffffff;
+        maxExpArray[67] = 0x067c00a3b07ffc01fd6fffffffffffffff;
+        maxExpArray[68] = 0x0637b647c39cbb9d3d27ffffffffffffff;
+        maxExpArray[69] = 0x05f63b1fc104dbd39587ffffffffffffff;
+        maxExpArray[70] = 0x05b771955b36e12f7235ffffffffffffff;
+        maxExpArray[71] = 0x057b3d49dda84556d6f6ffffffffffffff;
+        maxExpArray[72] = 0x054183095b2c8ececf30ffffffffffffff;
+        maxExpArray[73] = 0x050a28be635ca2b888f77fffffffffffff;
+        maxExpArray[74] = 0x04d5156639708c9db33c3fffffffffffff;
+        maxExpArray[75] = 0x04a23105873875bd52dfdfffffffffffff;
+        maxExpArray[76] = 0x0471649d87199aa990756fffffffffffff;
+        maxExpArray[77] = 0x04429a21a029d4c1457cfbffffffffffff;
+        maxExpArray[78] = 0x0415bc6d6fb7dd71af2cb3ffffffffffff;
+        maxExpArray[79] = 0x03eab73b3bbfe282243ce1ffffffffffff;
+        maxExpArray[80] = 0x03c1771ac9fb6b4c18e229ffffffffffff;
+        maxExpArray[81] = 0x0399e96897690418f785257fffffffffff;
+        maxExpArray[82] = 0x0373fc456c53bb779bf0ea9fffffffffff;
+        maxExpArray[83] = 0x034f9e8e490c48e67e6ab8bfffffffffff;
+        maxExpArray[84] = 0x032cbfd4a7adc790560b3337ffffffffff;
+        maxExpArray[85] = 0x030b50570f6e5d2acca94613ffffffffff;
+        maxExpArray[86] = 0x02eb40f9f620fda6b56c2861ffffffffff;
+        maxExpArray[87] = 0x02cc8340ecb0d0f520a6af58ffffffffff;
+        maxExpArray[88] = 0x02af09481380a0a35cf1ba02ffffffffff;
+        maxExpArray[89] = 0x0292c5bdd3b92ec810287b1b3fffffffff;
+        maxExpArray[90] = 0x0277abdcdab07d5a77ac6d6b9fffffffff;
+        maxExpArray[91] = 0x025daf6654b1eaa55fd64df5efffffffff;
+        maxExpArray[92] = 0x0244c49c648baa98192dce88b7ffffffff;
+        maxExpArray[93] = 0x022ce03cd5619a311b2471268bffffffff;
+        maxExpArray[94] = 0x0215f77c045fbe885654a44a0fffffffff;
+        maxExpArray[95] = 0x01ffffffffffffffffffffffffffffffff;
+        maxExpArray[96] = 0x01eaefdbdaaee7421fc4d3ede5ffffffff;
+        maxExpArray[97] = 0x01d6bd8b2eb257df7e8ca57b09bfffffff;
+        maxExpArray[98] = 0x01c35fedd14b861eb0443f7f133fffffff;
+        maxExpArray[99] = 0x01b0ce43b322bcde4a56e8ada5afffffff;
+        maxExpArray[100] = 0x019f0028ec1fff007f5a195a39dfffffff;
+        maxExpArray[101] = 0x018ded91f0e72ee74f49b15ba527ffffff;
+        maxExpArray[102] = 0x017d8ec7f04136f4e5615fd41a63ffffff;
+        maxExpArray[103] = 0x016ddc6556cdb84bdc8d12d22e6fffffff;
+        maxExpArray[104] = 0x015ecf52776a1155b5bd8395814f7fffff;
+        maxExpArray[105] = 0x015060c256cb23b3b3cc3754cf40ffffff;
+        maxExpArray[106] = 0x01428a2f98d728ae223ddab715be3fffff;
+        maxExpArray[107] = 0x013545598e5c23276ccf0ede68034fffff;
+        maxExpArray[108] = 0x01288c4161ce1d6f54b7f61081194fffff;
+        maxExpArray[109] = 0x011c592761c666aa641d5a01a40f17ffff;
+        maxExpArray[110] = 0x0110a688680a7530515f3e6e6cfdcdffff;
+        maxExpArray[111] = 0x01056f1b5bedf75c6bcb2ce8aed428ffff;
+        maxExpArray[112] = 0x00faadceceeff8a0890f3875f008277fff;
+        maxExpArray[113] = 0x00f05dc6b27edad306388a600f6ba0bfff;
+        maxExpArray[114] = 0x00e67a5a25da41063de1495d5b18cdbfff;
+        maxExpArray[115] = 0x00dcff115b14eedde6fc3aa5353f2e4fff;
+        maxExpArray[116] = 0x00d3e7a3924312399f9aae2e0f868f8fff;
+        maxExpArray[117] = 0x00cb2ff529eb71e41582cccd5a1ee26fff;
+        maxExpArray[118] = 0x00c2d415c3db974ab32a51840c0b67edff;
+        maxExpArray[119] = 0x00bad03e7d883f69ad5b0a186184e06bff;
+        maxExpArray[120] = 0x00b320d03b2c343d4829abd6075f0cc5ff;
+        maxExpArray[121] = 0x00abc25204e02828d73c6e80bcdb1a95bf;
+        maxExpArray[122] = 0x00a4b16f74ee4bb2040a1ec6c15fbbf2df;
+        maxExpArray[123] = 0x009deaf736ac1f569deb1b5ae3f36c130f;
+        maxExpArray[124] = 0x00976bd9952c7aa957f5937d790ef65037;
+        maxExpArray[125] = 0x009131271922eaa6064b73a22d0bd4f2bf;
+        maxExpArray[126] = 0x008b380f3558668c46c91c49a2f8e967b9;
+        maxExpArray[127] = 0x00857ddf0117efa215952912839f6473e6;
+    }
+
+    /**
+      General Description:
+          Determine a value of precision.
+          Calculate an integer approximation of (_baseN / _baseD) ^ (_expN / _expD) * 2 ^ precision.
+          Return the result along with the precision used.
+      Detailed Description:
+          Instead of calculating "base ^ exp", we calculate "e ^ (log(base) * exp)".
+          The value of "log(base)" is represented with an integer slightly smaller than "log(base) * 2 ^ precision".
+          The larger "precision" is, the more accurately this value represents the real value.
+          However, the larger "precision" is, the more bits are required in order to store this value.
+          And the exponentiation function, which takes "x" and calculates "e ^ x", is limited to a maximum exponent (maximum value of "x").
+          This maximum exponent depends on the "precision" used, and it is given by "maxExpArray[precision] >> (MAX_PRECISION - precision)".
+          Hence we need to determine the highest precision which can be used for the given input, before calling the exponentiation function.
+          This allows us to compute "base ^ exp" with maximum accuracy and without exceeding 256 bits in any of the intermediate computations.
+          This functions assumes that "_expN < 2 ^ 256 / log(MAX_NUM - 1)", otherwise the multiplication should be replaced with a "safeMul".
+    */
+    function power(
+        uint256 _baseN,
+        uint256 _baseD,
+        uint32 _expN,
+        uint32 _expD
+    ) internal view returns (uint256, uint8) {
+        require(_baseN < MAX_NUM, "baseN exceeds max value.");
+        require(_baseN >= _baseD, "Bases < 1 are not supported.");
+
+        uint256 baseLog;
+        uint256 base = (_baseN * FIXED_1) / _baseD;
+        if (base < OPT_LOG_MAX_VAL) {
+            baseLog = optimalLog(base);
+        } else {
+            baseLog = generalLog(base);
+        }
+
+        uint256 baseLogTimesExp = (baseLog * _expN) / _expD;
+        if (baseLogTimesExp < OPT_EXP_MAX_VAL) {
+            return (optimalExp(baseLogTimesExp), MAX_PRECISION);
+        } else {
+            uint8 precision = findPositionInMaxExpArray(baseLogTimesExp);
+            return (
+                generalExp(
+                    baseLogTimesExp >> (MAX_PRECISION - precision),
+                    precision
+                ),
+                precision
+            );
+        }
+    }
+
+    /**
+        Compute log(x / FIXED_1) * FIXED_1.
+        This functions assumes that "x >= FIXED_1", because the output would be negative otherwise.
+    */
+    function generalLog(uint256 _x) internal pure returns (uint256) {
+        uint256 res = 0;
+        uint256 x = _x;
+
+        // If x >= 2, then we compute the integer part of log2(x), which is larger than 0.
+        if (x >= FIXED_2) {
+            uint8 count = floorLog2(x / FIXED_1);
+            x >>= count; // now x < 2
+            res = count * FIXED_1;
+        }
+
+        // If x > 1, then we compute the fraction part of log2(x), which is larger than 0.
+        if (x > FIXED_1) {
+            for (uint8 i = MAX_PRECISION; i > 0; --i) {
+                x = (x * x) / FIXED_1; // now 1 < x < 4
+                if (x >= FIXED_2) {
+                    x >>= 1; // now 1 < x < 2
+                    res += ONE << (i - 1);
+                }
+            }
+        }
+
+        return (res * LN2_NUMERATOR) / LN2_DENOMINATOR;
+    }
+
+    /**
+      Compute the largest integer smaller than or equal to the binary logarithm of the input.
+    */
+    function floorLog2(uint256 _n) internal pure returns (uint8) {
+        uint8 res = 0;
+        uint256 n = _n;
+
+        if (n < 256) {
+            // At most 8 iterations
+            while (n > 1) {
+                n >>= 1;
+                res += 1;
+            }
+        } else {
+            // Exactly 8 iterations
+            for (uint8 s = 128; s > 0; s >>= 1) {
+                if (n >= (ONE << s)) {
+                    n >>= s;
+                    res |= s;
+                }
+            }
+        }
+
+        return res;
+    }
+
+    /**
+        The global "maxExpArray" is sorted in descending order, and therefore the following statements are equivalent:
+        - This function finds the position of [the smallest value in "maxExpArray" larger than or equal to "x"]
+        - This function finds the highest position of [a value in "maxExpArray" larger than or equal to "x"]
+    */
+    function findPositionInMaxExpArray(uint256 _x)
+        internal
+        view
+        returns (uint8)
+    {
+        uint8 lo = MIN_PRECISION;
+        uint8 hi = MAX_PRECISION;
+
+        while (lo + 1 < hi) {
+            uint8 mid = (lo + hi) / 2;
+            if (maxExpArray[mid] >= _x) lo = mid;
+            else hi = mid;
+        }
+
+        if (maxExpArray[hi] >= _x) return hi;
+        if (maxExpArray[lo] >= _x) return lo;
+
+        assert(false);
+        return 0;
+    }
+
+    /* solhint-disable */
+    /**
+        This function can be auto-generated by the script 'PrintFunctionGeneralExp.py'.
+        It approximates "e ^ x" via maclaurin summation: "(x^0)/0! + (x^1)/1! + ... + (x^n)/n!".
+        It returns "e ^ (x / 2 ^ precision) * 2 ^ precision", that is, the result is upshifted for accuracy.
+        The global "maxExpArray" maps each "precision" to "((maximumExponent + 1) << (MAX_PRECISION - precision)) - 1".
+        The maximum permitted value for "x" is therefore given by "maxExpArray[precision] >> (MAX_PRECISION - precision)".
+    */
+    function generalExp(uint256 _x, uint8 _precision)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 xi = _x;
+        uint256 res = 0;
+
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x3442c4e6074a82f1797f72ac0000000; // add x^02 * (33! / 02!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x116b96f757c380fb287fd0e40000000; // add x^03 * (33! / 03!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x045ae5bdd5f0e03eca1ff4390000000; // add x^04 * (33! / 04!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00defabf91302cd95b9ffda50000000; // add x^05 * (33! / 05!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x002529ca9832b22439efff9b8000000; // add x^06 * (33! / 06!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00054f1cf12bd04e516b6da88000000; // add x^07 * (33! / 07!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000a9e39e257a09ca2d6db51000000; // add x^08 * (33! / 08!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000012e066e7b839fa050c309000000; // add x^09 * (33! / 09!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000001e33d7d926c329a1ad1a800000; // add x^10 * (33! / 10!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000002bee513bdb4a6b19b5f800000; // add x^11 * (33! / 11!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000003a9316fa79b88eccf2a00000; // add x^12 * (33! / 12!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000048177ebe1fa812375200000; // add x^13 * (33! / 13!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000005263fe90242dcbacf00000; // add x^14 * (33! / 14!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000000000057e22099c030d94100000; // add x^15 * (33! / 15!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000057e22099c030d9410000; // add x^16 * (33! / 16!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000052b6b54569976310000; // add x^17 * (33! / 17!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000004985f67696bf748000; // add x^18 * (33! / 18!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000000000000003dea12ea99e498000; // add x^19 * (33! / 19!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000000031880f2214b6e000; // add x^20 * (33! / 20!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000000000000000025bcff56eb36000; // add x^21 * (33! / 21!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000000000000000001b722e10ab1000; // add x^22 * (33! / 22!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000000000001317c70077000; // add x^23 * (33! / 23!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000000000000cba84aafa00; // add x^24 * (33! / 24!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000000000000082573a0a00; // add x^25 * (33! / 25!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000000000000005035ad900; // add x^26 * (33! / 26!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x000000000000000000000002f881b00; // add x^27 * (33! / 27!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000000000000000001b29340; // add x^28 * (33! / 28!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x00000000000000000000000000efc40; // add x^29 * (33! / 29!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000000000000000000007fe0; // add x^30 * (33! / 30!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000000000000000000000420; // add x^31 * (33! / 31!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000000000000000000000021; // add x^32 * (33! / 32!)
+        xi = (xi * _x) >> _precision;
+        res += xi * 0x0000000000000000000000000000001; // add x^33 * (33! / 33!)
+
+        return
+            res / 0x688589cc0e9505e2f2fee5580000000 + _x + (ONE << _precision); // divide by 33! and then add x^1 / 1! + x^0 / 0!
+    }
+
+    /**
+        Return log(x / FIXED_1) * FIXED_1
+        Input range: FIXED_1 <= x <= LOG_EXP_MAX_VAL - 1
+        Auto-generated via 'PrintFunctionOptimalLog.py'
+    */
+    function optimalLog(uint256 x) internal pure returns (uint256) {
+        uint256 res = 0;
+
+        uint256 y;
+        uint256 z;
+        uint256 w;
+
+        if (x >= 0xd3094c70f034de4b96ff7d5b6f99fcd8) {
+            res += 0x40000000000000000000000000000000;
+            x = (x * FIXED_1) / 0xd3094c70f034de4b96ff7d5b6f99fcd8;
+        }
+        if (x >= 0xa45af1e1f40c333b3de1db4dd55f29a7) {
+            res += 0x20000000000000000000000000000000;
+            x = (x * FIXED_1) / 0xa45af1e1f40c333b3de1db4dd55f29a7;
+        }
+        if (x >= 0x910b022db7ae67ce76b441c27035c6a1) {
+            res += 0x10000000000000000000000000000000;
+            x = (x * FIXED_1) / 0x910b022db7ae67ce76b441c27035c6a1;
+        }
+        if (x >= 0x88415abbe9a76bead8d00cf112e4d4a8) {
+            res += 0x08000000000000000000000000000000;
+            x = (x * FIXED_1) / 0x88415abbe9a76bead8d00cf112e4d4a8;
+        }
+        if (x >= 0x84102b00893f64c705e841d5d4064bd3) {
+            res += 0x04000000000000000000000000000000;
+            x = (x * FIXED_1) / 0x84102b00893f64c705e841d5d4064bd3;
+        }
+        if (x >= 0x8204055aaef1c8bd5c3259f4822735a2) {
+            res += 0x02000000000000000000000000000000;
+            x = (x * FIXED_1) / 0x8204055aaef1c8bd5c3259f4822735a2;
+        }
+        if (x >= 0x810100ab00222d861931c15e39b44e99) {
+            res += 0x01000000000000000000000000000000;
+            x = (x * FIXED_1) / 0x810100ab00222d861931c15e39b44e99;
+        }
+        if (x >= 0x808040155aabbbe9451521693554f733) {
+            res += 0x00800000000000000000000000000000;
+            x = (x * FIXED_1) / 0x808040155aabbbe9451521693554f733;
+        }
+
+        z = y = x - FIXED_1;
+        w = (y * y) / FIXED_1;
+        res +=
+            (z * (0x100000000000000000000000000000000 - y)) /
+            0x100000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa - y)) /
+            0x200000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x099999999999999999999999999999999 - y)) /
+            0x300000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x092492492492492492492492492492492 - y)) /
+            0x400000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x08e38e38e38e38e38e38e38e38e38e38e - y)) /
+            0x500000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x08ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8b - y)) /
+            0x600000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x089d89d89d89d89d89d89d89d89d89d89 - y)) /
+            0x700000000000000000000000000000000;
+        z = (z * w) / FIXED_1;
+        res +=
+            (z * (0x088888888888888888888888888888888 - y)) /
+            0x800000000000000000000000000000000;
+
+        return res;
+    }
+
+    /**
+        Return e ^ (x / FIXED_1) * FIXED_1
+        Input range: 0 <= x <= OPT_EXP_MAX_VAL - 1
+        Auto-generated via 'PrintFunctionOptimalExp.py'
+    */
+    function optimalExp(uint256 x) internal pure returns (uint256) {
+        uint256 res = 0;
+
+        uint256 y;
+        uint256 z;
+
+        z = y = x % 0x10000000000000000000000000000000;
+        z = (z * y) / FIXED_1;
+        res += z * 0x10e1b3be415a0000; // add y^02 * (20! / 02!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x05a0913f6b1e0000; // add y^03 * (20! / 03!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0168244fdac78000; // add y^04 * (20! / 04!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x004807432bc18000; // add y^05 * (20! / 05!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x000c0135dca04000; // add y^06 * (20! / 06!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0001b707b1cdc000; // add y^07 * (20! / 07!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x000036e0f639b800; // add y^08 * (20! / 08!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x00000618fee9f800; // add y^09 * (20! / 09!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000009c197dcc00; // add y^10 * (20! / 10!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000000e30dce400; // add y^11 * (20! / 11!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x000000012ebd1300; // add y^12 * (20! / 12!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000000017499f00; // add y^13 * (20! / 13!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000000001a9d480; // add y^14 * (20! / 14!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x00000000001c6380; // add y^15 * (20! / 15!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x000000000001c638; // add y^16 * (20! / 16!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000000000001ab8; // add y^17 * (20! / 17!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x000000000000017c; // add y^18 * (20! / 18!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000000000000014; // add y^19 * (20! / 19!)
+        z = (z * y) / FIXED_1;
+        res += z * 0x0000000000000001; // add y^20 * (20! / 20!)
+        res = res / 0x21c3677c82b40000 + y + FIXED_1; // divide by 20! and then add y^1 / 1! + y^0 / 0!
+
+        if ((x & 0x010000000000000000000000000000000) != 0)
+            res =
+                (res * 0x1c3d6a24ed82218787d624d3e5eba95f9) /
+                0x18ebef9eac820ae8682b9793ac6d1e776;
+        if ((x & 0x020000000000000000000000000000000) != 0)
+            res =
+                (res * 0x18ebef9eac820ae8682b9793ac6d1e778) /
+                0x1368b2fc6f9609fe7aceb46aa619baed4;
+        if ((x & 0x040000000000000000000000000000000) != 0)
+            res =
+                (res * 0x1368b2fc6f9609fe7aceb46aa619baed5) /
+                0x0bc5ab1b16779be3575bd8f0520a9f21f;
+        if ((x & 0x080000000000000000000000000000000) != 0)
+            res =
+                (res * 0x0bc5ab1b16779be3575bd8f0520a9f21e) /
+                0x0454aaa8efe072e7f6ddbab84b40a55c9;
+        if ((x & 0x100000000000000000000000000000000) != 0)
+            res =
+                (res * 0x0454aaa8efe072e7f6ddbab84b40a55c5) /
+                0x00960aadc109e7a3bf4578099615711ea;
+        if ((x & 0x200000000000000000000000000000000) != 0)
+            res =
+                (res * 0x00960aadc109e7a3bf4578099615711d7) /
+                0x0002bf84208204f5977f9a8cf01fdce3d;
+        if ((x & 0x400000000000000000000000000000000) != 0)
+            res =
+                (res * 0x0002bf84208204f5977f9a8cf01fdc307) /
+                0x0000003c6ab775dd0b95b4cbee7e65d11;
+
+        return res;
+    }
+    /* solhint-enable */
+}

--- a/contracts/PermanentCuratorVault/IPermanentCuratorVault.sol
+++ b/contracts/PermanentCuratorVault/IPermanentCuratorVault.sol
@@ -1,0 +1,7 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+/// @dev Interface for the curator vault
+interface IPermanentCuratorVault {
+
+}

--- a/contracts/PermanentCuratorVault/PermanentCuratorVault.sol
+++ b/contracts/PermanentCuratorVault/PermanentCuratorVault.sol
@@ -1,0 +1,157 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "./IPermanentCuratorVault.sol";
+import "./PermanentCuratorVaultStorage.sol";
+import "./Curve/BancorFormula.sol";
+
+/// @title PermanentCuratorVault
+/// @dev This contract tracks shares in a bonding curve per Taker NFT.
+/// When users spend reactions against a Taker NFT, it will use the Curator Liability
+/// to buy curator shares against that Taker NFT and allocate to various parties.
+/// The curator shares will be priced via an increasing price curve.
+/// At any point in time the owners of the curator shares can sell them back to the
+/// bonding curve.
+contract PermanentCuratorVault is
+    BancorFormula,
+    PermanentCuratorVaultStorageV1
+{
+    /// @dev Use the safe methods when interacting with transfers with outside ERC20s
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    /// @dev verifies that the calling address is the reaction vault
+    modifier onlyReactionVault() {
+        require(
+            address(addressManager.reactionVault()) == msg.sender,
+            "Not ReactionVault"
+        );
+        _;
+    }
+
+    /// @dev Event triggered when curator shares are purchased
+    event CuratorSharesBought(
+        uint256 indexed curatorShareTokenId,
+        uint256 paymentTokenPaid,
+        uint256 curatorSharesBought
+    );
+
+    /// @dev Event triggered when curator shares are sold
+    event CuratorSharesSold(
+        uint256 indexed curatorShareTokenId,
+        uint256 paymentTokenRefunded,
+        uint256 curatorSharesSold
+    );
+
+    /// @dev initializer to call after deployment, can only be called once
+    function initialize(
+        address _addressManager,
+        uint32 _reserveRatio,
+        IStandard1155 _curatorShares
+    ) public initializer {
+        __Power_init();
+
+        // Save the address manager
+        addressManager = IAddressManager(_addressManager);
+
+        // Save the reserve ratio
+        reserveRatio = _reserveRatio;
+
+        // Save the curator share contract
+        curatorShares = _curatorShares;
+    }
+
+    /// @dev get a unique token ID for a given nft address and nft ID
+    function getTokenId(address nftAddress, uint256 nftId)
+        public
+        pure
+        returns (uint256)
+    {
+        return uint256(keccak256(abi.encode(nftAddress, nftId)));
+    }
+
+    /// @dev Buy curator shares when reactions are spent.
+    /// The reaction vault is the only account allowed to call this.
+    /// @return Returns the amount of curator shares purchased.
+    function buyCuratorShares(
+        address nftAddress,
+        uint256 nftId,
+        uint256 paymentAmount,
+        address mintToAddress
+    ) public onlyReactionVault returns (uint256) {
+        // Get the curator share token ID
+        uint256 curatorShareTokenId = getTokenId(nftAddress, nftId);
+
+        // Move payment tokens in
+        IParameterManager parameterManager = addressManager.parameterManager();
+        IERC20Upgradeable paymentToken = parameterManager.paymentToken();
+        // TODO: use _msgSender() for GSN compatability
+        paymentToken.safeTransferFrom(msg.sender, address(this), paymentAmount);
+
+        // Calculate how many tokens should be minted
+        uint256 curatorShareAmount = calculatePurchaseReturn(
+            SUPPLY_BUFFER + curatorShareSupply[curatorShareTokenId],
+            RESERVE_BUFFER + reserves[curatorShareTokenId],
+            reserveRatio,
+            paymentAmount
+        );
+
+        // Mint the tokens
+        curatorShares.mint(
+            mintToAddress,
+            curatorShareTokenId,
+            curatorShareAmount,
+            new bytes(0)
+        );
+
+        // Update the amounts
+        reserves[curatorShareTokenId] += paymentAmount;
+        curatorShareSupply[curatorShareTokenId] += curatorShareAmount;
+
+        // Emit the event
+        emit CuratorSharesBought(
+            curatorShareTokenId,
+            paymentAmount,
+            curatorShareAmount
+        );
+
+        return curatorShareAmount;
+    }
+
+    /// @dev Sell curator shares back into the bonding curve.
+    /// Any holder who owns shares can sell them back
+    /// @return Returns the amount of payment tokens received for the curator shares.
+    function sellCuratorShares(
+        address nftAddress,
+        uint256 nftId,
+        uint256 sharesToBurn
+    ) public returns (uint256) {
+        // Get the curator share token ID
+        uint256 curatorShareTokenId = getTokenId(nftAddress, nftId);
+
+        // Burn the curator shares
+        curatorShares.burn(msg.sender, curatorShareTokenId, sharesToBurn);
+
+        // Calculate the amount of tokens to send back
+        uint256 refundAmount = calculateSaleReturn(
+            SUPPLY_BUFFER + curatorShareSupply[curatorShareTokenId],
+            RESERVE_BUFFER + reserves[curatorShareTokenId],
+            reserveRatio,
+            sharesToBurn
+        );
+
+        // Send the tokens
+        IParameterManager parameterManager = addressManager.parameterManager();
+        IERC20Upgradeable paymentToken = parameterManager.paymentToken();
+        paymentToken.safeTransfer(address(this), refundAmount);
+
+        // Update the amounts
+        reserves[curatorShareTokenId] -= refundAmount;
+        curatorShareSupply[curatorShareTokenId] -= sharesToBurn;
+
+        // Emit the event
+        emit CuratorSharesSold(curatorShareTokenId, refundAmount, sharesToBurn);
+
+        return refundAmount;
+    }
+}

--- a/contracts/PermanentCuratorVault/PermanentCuratorVaultStorage.sol
+++ b/contracts/PermanentCuratorVault/PermanentCuratorVaultStorage.sol
@@ -1,0 +1,47 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../Config/IAddressManager.sol";
+import "./IPermanentCuratorVault.sol";
+
+/// @title PermanentCuratorVaultStorage
+/// @dev This contract will hold all local variables for the PermanentCuratorVault Contract
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the
+/// CuratorVault to inherit from the later version.  This ensures there are no storage layout
+/// corruptions when upgrading.
+contract PermanentCuratorVaultStorageV1 is IPermanentCuratorVault {
+    /// @dev local reference to the address manager contract
+    IAddressManager public addressManager;
+
+    /// @dev Buffer on reserve amount so that it doesn't start with 0
+    uint256 public constant RESERVE_BUFFER = 100000;
+
+    /// @dev Buffer on supply amount so that it doesn't start with 0
+    uint256 public constant SUPPLY_BUFFER = 1000000;
+
+    /*
+        reserve ratio, represented in ppm, 1-1000000
+        1/3 corresponds to y= multiple * x^2
+        1/2 corresponds to y= multiple * x
+        2/3 corresponds to y= multiple * x^1/2
+    */
+    /// @dev The reserve ratio of the bonding curve => 300000 == 30%
+    uint32 public reserveRatio;
+
+    /// @dev tracks the total supply for each curator share token ID
+    mapping(uint256 => uint256) public curatorShareSupply;
+
+    /// @dev tracks the total payment amount held for each curator share token ID
+    mapping(uint256 => uint256) public reserves;
+
+    /// @dev the 1155 contract to track curator shares
+    IStandard1155 public curatorShares;
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract PermanentCuratorVaultStorageV2 is PermanentCuratorVaultStorageV1 {
+  address newVariable;
+}
+ */

--- a/contracts/PermanentCuratorVault/Shares/CuratorShares1155.sol
+++ b/contracts/PermanentCuratorVault/Shares/CuratorShares1155.sol
@@ -1,0 +1,37 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../../Token/Standard1155.sol";
+
+/// @title CuratorShares1155
+/// @dev This contract will be used to track Curator Share ownership
+/// Only the Curator Vault can mint or burn shares
+contract CuratorShares1155 is Standard1155 {
+    /// @dev verifies that the calling account is the curator vault
+    modifier onlyCuratorVault() {
+        require(
+            address(addressManager.defaultCuratorVault()) == msg.sender,
+            "Not CuratorVault"
+        );
+        _;
+    }
+
+    /// @dev Allows reaction minter role to mint tokens
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external onlyCuratorVault {
+        _mint(to, id, amount, data);
+    }
+
+    /// @dev Allows reaction burner role to burn tokens
+    function burn(
+        address from,
+        uint256 id,
+        uint256 amount
+    ) external onlyCuratorVault {
+        _burn(from, id, amount);
+    }
+}

--- a/contracts/Reactions/NFT/ReactionNft1155.sol
+++ b/contracts/Reactions/NFT/ReactionNft1155.sol
@@ -1,0 +1,43 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../../Token/Standard1155.sol";
+
+/// @title ReactionNft1155
+/// @dev This contract will be used to track Reaction NFTs in the protocol.
+/// Only the NFT Minter role can mint tokens
+/// Only the NFT Burner role can burn tokens
+contract ReactionNft1155 is Standard1155 {
+    /// @dev verifies that the calling account has a role to enable minting tokens
+    modifier onlyMinter() {
+        IRoleManager roleManager = IRoleManager(addressManager.roleManager());
+        require(roleManager.isReactionMinter(msg.sender), "Not Minter");
+        _;
+    }
+
+    /// @dev verifies that the calling account has a role to enable burning tokens
+    modifier onlyBurner() {
+        IRoleManager roleManager = IRoleManager(addressManager.roleManager());
+        require(roleManager.isReactionBurner(msg.sender), "Not Burner");
+        _;
+    }
+
+    /// @dev Allows reaction minter role to mint tokens
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external onlyMinter {
+        _mint(to, id, amount, data);
+    }
+
+    /// @dev Allows reaction burner role to burn tokens
+    function burn(
+        address from,
+        uint256 id,
+        uint256 amount
+    ) external onlyBurner {
+        _burn(from, id, amount);
+    }
+}

--- a/contracts/Testing/TestErc1155.sol
+++ b/contracts/Testing/TestErc1155.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../Token/Standard1155.sol";
+
+/// @title TestErc1155
+/// @dev This contract implements the ERC115 standard and is used for unit testing purposes only
+/// Anyone can mint or burn tokens
+contract TestErc1155 is Standard1155 {
+    /// @dev Allows anyone to mint tokens
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external {
+        _mint(to, id, amount, data);
+    }
+
+    /// @dev allows anyone to burn tokens
+    function burn(
+        address from,
+        uint256 id,
+        uint256 amount
+    ) external {
+        _burn(from, id, amount);
+    }
+}

--- a/contracts/Token/IStandard1155.sol
+++ b/contracts/Token/IStandard1155.sol
@@ -10,4 +10,10 @@ interface IStandard1155 {
         uint256 amount,
         bytes memory data
     ) external;
+
+    function burn(
+        address from,
+        uint256 id,
+        uint256 amount
+    ) external;
 }

--- a/contracts/Token/Standard1155.sol
+++ b/contracts/Token/Standard1155.sol
@@ -2,24 +2,16 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
-import "../Permissions/IRoleManager.sol";
 import "./IStandard1155.sol";
 import "./Standard1155Storage.sol";
 
 /// @title Standard1155
 /// @dev This contract implements the 1155 standard
-contract Standard1155 is
+abstract contract Standard1155 is
     IStandard1155,
     ERC1155Upgradeable,
     Standard1155StorageV1
 {
-    /// @dev verifies that the calling account has a role to enable minting tokens
-    modifier onlyMinter() {
-        IRoleManager roleManager = IRoleManager(addressManager.roleManager());
-        require(roleManager.isReactionMinter(msg.sender), "Not Minter");
-        _;
-    }
-
     /// @dev initializer to call after deployment, can only be called once
     function initialize(string memory _uri, address _addressManager)
         public
@@ -29,15 +21,5 @@ contract Standard1155 is
         __ERC1155_init(_uri);
 
         addressManager = IAddressManager(_addressManager);
-    }
-
-    /// @dev Allows a priviledged account to mint tokens to the specified address
-    function mint(
-        address to,
-        uint256 id,
-        uint256 amount,
-        bytes memory data
-    ) external onlyMinter {
-        _mint(to, id, amount, data);
     }
 }

--- a/test/Config/AddressManager.ts
+++ b/test/Config/AddressManager.ts
@@ -123,4 +123,26 @@ describe("AddressManager", function () {
       addressManager.connect(ALICE).setReactionNftContract(BOB.address)
     ).to.revertedWith(NOT_ADMIN);
   });
+
+  it("Should allow owner to set reaction Vault address", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { addressManager } = await deploySystem(OWNER);
+
+    // Verify the setter checks invalid input
+    await expect(addressManager.setReactionVault(ZERO_ADDRESS)).to.revertedWith(
+      INVALID_ZERO_PARAM
+    );
+
+    // Set it to Alice's address
+    await addressManager.setReactionVault(ALICE.address);
+
+    // Verify it got set
+    const currentVal = await addressManager.reactionVault();
+    expect(currentVal).to.equal(ALICE.address);
+
+    // Verify non owner can't update address
+    await expect(
+      addressManager.connect(ALICE).setReactionVault(BOB.address)
+    ).to.revertedWith(NOT_ADMIN);
+  });
 });

--- a/test/CuratorVault/CuratorShares.ts
+++ b/test/CuratorVault/CuratorShares.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deploySystem } from "../Scripts/deploy";
+import { NOT_CURATOR_VAULT } from "../Scripts/errors";
+
+describe("CuratorShares", function () {
+  it("Should get initialized with address manager", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { curatorShares, addressManager } = await deploySystem(OWNER);
+
+    // Verify the address manager was set
+    const currentAddressManager = await curatorShares.addressManager();
+    expect(currentAddressManager).to.equal(addressManager.address);
+  });
+
+  it("Should only allow curator vault to mint or burn", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { curatorShares, addressManager } = await deploySystem(OWNER);
+
+    // Verify mint fails
+    await expect(
+      curatorShares.mint(ALICE.address, "1", "1", [0])
+    ).to.be.revertedWith(NOT_CURATOR_VAULT);
+
+    // Set the owner as the curator vault to test it succeeding
+    await addressManager.setDefaultCuratorVault(OWNER.address);
+
+    // Should succeed now
+    await curatorShares.mint(ALICE.address, "1", "1", [0]);
+
+    // Bob should not be allowed to burn
+    await expect(
+      curatorShares.connect(BOB).mint(ALICE.address, "1", "1", [0])
+    ).to.be.revertedWith(NOT_CURATOR_VAULT);
+
+    // Should succeed
+    await curatorShares.burn(ALICE.address, "1", "1");
+  });
+});

--- a/test/CuratorVault/CuratorVault.ts
+++ b/test/CuratorVault/CuratorVault.ts
@@ -1,0 +1,149 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { ZERO_ADDRESS } from "../Scripts/constants";
+import { deploySystem } from "../Scripts/deploy";
+import {
+  NOT_REACTION_VAULT,
+  NO_BALANCE,
+  TRANSFER_NOT_ALLOWED,
+} from "../Scripts/errors";
+
+describe("CuratorVault", function () {
+  it("Should get initialized with address manager", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { curatorVault, addressManager } = await deploySystem(OWNER);
+
+    // Verify the address manager was set
+    const currentAddressManager = await curatorVault.addressManager();
+    expect(currentAddressManager).to.equal(addressManager.address);
+  });
+
+  it("Should not allow address other than reaction vault purchase", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { curatorVault } = await deploySystem(OWNER);
+
+    // Should fail
+    await expect(
+      curatorVault.buyCuratorShares(ZERO_ADDRESS, "1", "1", OWNER.address)
+    ).to.be.revertedWith(NOT_REACTION_VAULT);
+  });
+
+  it("Should verify payment token", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { curatorVault, addressManager, paymentTokenErc20 } =
+      await deploySystem(OWNER);
+
+    // Set the owner as the address manager to allow purchase to be tried
+    await addressManager.setReactionVault(OWNER.address);
+
+    // Should fail
+    await expect(
+      curatorVault.buyCuratorShares(ZERO_ADDRESS, "1", "1", OWNER.address)
+    ).to.be.revertedWith(NO_BALANCE);
+
+    // Give the account a balance
+    await paymentTokenErc20.mint(OWNER.address, "1000000000");
+
+    // Should fail
+    await expect(
+      curatorVault.buyCuratorShares(ZERO_ADDRESS, "1", "1", OWNER.address)
+    ).to.be.revertedWith(TRANSFER_NOT_ALLOWED);
+  });
+
+  it("Should allow purchase and sale", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { curatorVault, addressManager, paymentTokenErc20, curatorShares } =
+      await deploySystem(OWNER);
+
+    // Set the owner as the address manager to allow purchase
+    await addressManager.setReactionVault(OWNER.address);
+
+    const paymentAmount = "10000";
+
+    // Give the account a balance
+    await paymentTokenErc20.mint(OWNER.address, paymentAmount);
+
+    // Approve the tokens
+    await paymentTokenErc20.approve(curatorVault.address, paymentAmount);
+
+    // Get the curator share ID
+    const curatorShareId = await curatorVault.getTokenId(ZERO_ADDRESS, "1");
+
+    // Expected amount for first purchase
+    const expectedAmount = "38860";
+
+    // Buy curator shares for the owner
+    await expect(
+      curatorVault.buyCuratorShares(
+        ZERO_ADDRESS,
+        "1",
+        paymentAmount,
+        OWNER.address
+      )
+    )
+      .to.emit(curatorVault, "CuratorSharesBought")
+      .withArgs(curatorShareId, paymentAmount, expectedAmount);
+
+    // Verify the shares were bought
+    expect(
+      await curatorShares.balanceOf(OWNER.address, curatorShareId)
+    ).to.equal(expectedAmount);
+
+    // Now sell it back and get back full amount of funds
+    await expect(
+      curatorVault.sellCuratorShares(ZERO_ADDRESS, "1", expectedAmount)
+    )
+      .to.emit(curatorVault, "CuratorSharesSold")
+      .withArgs(curatorShareId, "9999", expectedAmount); // 9999 due to precision loss
+  });
+
+  it("Should allow purchase and sale with increasing price", async function () {
+    const [OWNER, ALICE] = await ethers.getSigners();
+    const { curatorVault, addressManager, paymentTokenErc20, curatorShares } =
+      await deploySystem(OWNER);
+
+    // Set the owner as the address manager to allow purchase
+    await addressManager.setReactionVault(OWNER.address);
+
+    const paymentAmount = "10000";
+
+    // Give the account a balance
+    await paymentTokenErc20.mint(OWNER.address, paymentAmount);
+    await paymentTokenErc20.mint(ALICE.address, paymentAmount);
+
+    // Approve the tokens
+    await paymentTokenErc20.approve(curatorVault.address, paymentAmount);
+    await paymentTokenErc20
+      .connect(ALICE)
+      .approve(curatorVault.address, paymentAmount);
+
+    // Buy for the owner
+    await curatorVault.buyCuratorShares(
+      ZERO_ADDRESS,
+      "1",
+      paymentAmount,
+      OWNER.address
+    );
+
+    // Set the address to allow alice to buy
+    await addressManager.setReactionVault(ALICE.address);
+
+    await curatorVault
+      .connect(ALICE)
+      .buyCuratorShares(ZERO_ADDRESS, "1", paymentAmount, ALICE.address);
+
+    // Get the curator share ID
+    const curatorShareId = await curatorVault.getTokenId(ZERO_ADDRESS, "1");
+
+    const ownerBalance = await curatorShares.balanceOf(
+      OWNER.address,
+      curatorShareId
+    );
+    const aliceBalance = await curatorShares.balanceOf(
+      ALICE.address,
+      curatorShareId
+    );
+
+    expect(ownerBalance.toNumber()).to.be.greaterThan(aliceBalance.toNumber());
+  });
+});

--- a/test/Reaction/ReactionVault.ts
+++ b/test/Reaction/ReactionVault.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import { EPERM } from "constants";
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 import { ZERO_ADDRESS } from "../Scripts/constants";

--- a/test/Scripts/errors.ts
+++ b/test/Scripts/errors.ts
@@ -5,6 +5,8 @@ const NFT_NOT_FOUND = "NFT not found";
 const NFT_NOT_OWNED = "NFT not owned";
 const NFT_NOT_REGISTERED = "NFT not registered";
 const NOT_ADMIN = "Not Admin";
+const NOT_CURATOR_VAULT = "Not CuratorVault";
+const NOT_REACTION_VAULT = "Not ReactionVault";
 const NO_BALANCE = "ERC20: transfer amount exceeds balance";
 const TRANSFER_NOT_ALLOWED = "ERC20: transfer amount exceeds allowance";
 const UNKNOWN_NFT = "Unknown NFT";
@@ -17,6 +19,8 @@ export {
   NFT_NOT_OWNED,
   NFT_NOT_REGISTERED,
   NOT_ADMIN,
+  NOT_CURATOR_VAULT,
+  NOT_REACTION_VAULT,
   NO_BALANCE,
   TRANSFER_NOT_ALLOWED,
   UNKNOWN_NFT,

--- a/test/Token/Standard1155.ts
+++ b/test/Token/Standard1155.ts
@@ -18,11 +18,11 @@ describe("Standard1155 Token", function () {
 
   it("Should mint tokens if authorized", async function () {
     const [OWNER, ALICE, BOB] = await ethers.getSigners();
-    const { testingStandard1155, roleManager } = await deploySystem(OWNER);
+    const { reactionNFT1155, roleManager } = await deploySystem(OWNER);
 
     // Verify Bob's non-authorized acct can't mint
     await expect(
-      testingStandard1155.connect(BOB).mint(ALICE.address, "1", "1000", [0])
+      reactionNFT1155.connect(BOB).mint(ALICE.address, "1", "1000", [0])
     ).to.be.reverted;
 
     // Grant authorization to Bob
@@ -30,19 +30,19 @@ describe("Standard1155 Token", function () {
     roleManager.grantRole(reactionMinterRole, BOB.address);
 
     // Mint again
-    testingStandard1155.connect(BOB).mint(ALICE.address, "1", "1000", [0]);
+    reactionNFT1155.connect(BOB).mint(ALICE.address, "1", "1000", [0]);
 
     // Verify balance
-    let balance = await testingStandard1155.balanceOf(ALICE.address, "1");
+    let balance = await reactionNFT1155.balanceOf(ALICE.address, "1");
     expect(balance.toString()).to.equal("1000");
 
     // Verify transfer
-    await testingStandard1155
+    await reactionNFT1155
       .connect(ALICE)
       .safeTransferFrom(ALICE.address, BOB.address, "1", "250", [0]);
 
     // Verify Bob balance
-    balance = await testingStandard1155.balanceOf(BOB.address, "1");
+    balance = await reactionNFT1155.balanceOf(BOB.address, "1");
     expect(balance.toString()).to.equal("250");
   });
 });


### PR DESCRIPTION
This PR adds the `PermanentCuratorVault` contract which allows the reaction vault to buy curator shares on a bonding curve.

I initially tried create the curator vault have the token built in but the contract size became too large to deploy.  The curator shares are now tracked in a separate contract `CuratorShares`.

We will need to tweak the parameters in the curve before deploying but I set some reasonable initial ones.
* reserve ratio of 400000
* reserve buffer of 100000
* supply buffer of 1000000

The reserve and supply buffers were needed to prevent the values being 0 on the first purchase, and this also allows a larger amount of tokens to be bought with a larger value.