### PR TITLE
Erc20 Reward withdraw

### DIFF
--- a/contracts/Reactions/ReactionVault.sol
+++ b/contracts/Reactions/ReactionVault.sol
@@ -84,6 +84,9 @@ contract ReactionVault is
         uint256 curatorShareAmount
     );
 
+    /// @dev Event emitted when an account withdraws ERC20 rewards
+    event ERC20RewardsClaimed(address token, uint256 amount, address recipient);
+
     /// @dev initializer to call after deployment, can only be called once
     function initialize(IAddressManager _addressManager) public initializer {
         __ReentrancyGuard_init();
@@ -433,6 +436,9 @@ contract ReactionVault is
 
         // Send tokens
         token.safeTransfer(msg.sender, rewardAmount);
+
+        // Emit event
+        emit ERC20RewardsClaimed(address(token), rewardAmount, msg.sender);
 
         // Return amount sent
         return rewardAmount;

--- a/test/Reaction/ReactionVaultRewards.ts
+++ b/test/Reaction/ReactionVaultRewards.ts
@@ -11,7 +11,7 @@ import {
 import { deriveMakerNftMetaId } from "../Scripts/derivedParams";
 import { INVALID_ZERO_PARAM } from "../Scripts/errors";
 
-describe.only("ReactionVault Withdraw ERC20", function () {
+describe("ReactionVault Withdraw ERC20", function () {
   it("Should buy a single reaction", async function () {
     const [OWNER, MAKER, CREATOR, REFERRER, ALICE] = await ethers.getSigners();
     const {
@@ -87,10 +87,15 @@ describe.only("ReactionVault Withdraw ERC20", function () {
       reactionVault.withdrawErc20Rewards(ALICE.address)
     ).to.be.revertedWith(INVALID_ZERO_PARAM);
 
-    // Withdraw creator rewards
-    await reactionVault
-      .connect(CREATOR)
-      .withdrawErc20Rewards(paymentTokenErc20.address);
+    // Withdraw creator rewards and event
+    await expect(
+      reactionVault
+        .connect(CREATOR)
+        .withdrawErc20Rewards(paymentTokenErc20.address)
+    )
+      .to.emit(reactionVault, "ERC20RewardsClaimed")
+      .withArgs(paymentTokenErc20.address, CREATOR_CUT, CREATOR.address);
+
     let balance = await paymentTokenErc20.balanceOf(CREATOR.address);
     expect(balance.toString()).to.be.equal(CREATOR_CUT.toString());
 


### PR DESCRIPTION
This PR allows a user who has been allocated rewards to withdraw them.  This PR is specifically for ERC20 payment token rewards.

This PR branches off of #16 so that one should be merged before reviewing this one.