### PR TITLE
Use polygon bridge for l1-l2 registration

### DIFF
--- a/contracts/Bridge/ChildRegistrar.sol
+++ b/contracts/Bridge/ChildRegistrar.sol
@@ -1,0 +1,85 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@maticnetwork/fx-portal/contracts/tunnel/FxBaseChildTunnel.sol";
+import "../Config/IAddressManager.sol";
+
+/// @dev This contract lives on the L2 and receives messages from the L1 to register and unregister
+/// NFTs on the L1 chain.
+/// This is not an upgradeable contract and should not be used with a proxy.
+contract ChildRegistrar is FxBaseChildTunnel {
+    bytes32 public constant REGISTER = keccak256("REGISTER");
+    bytes32 public constant DE_REGISTER = keccak256("DE_REGISTER");
+
+    /// @dev local reference to the address manager contract
+    IAddressManager public addressManager;
+
+    /// @param _fxChild - This is the contract deployed on the L2 that will be sending messages here.
+    /// This is a well known deployed contract that Matic has set up.
+    /// @param _addressManager - This is the address manager on the protocol
+    /// @dev After deployment you must call setFxRootTunnel() with the RootRegistrar Address on the L1.
+    constructor(address _fxChild, IAddressManager _addressManager)
+        FxBaseChildTunnel(_fxChild)
+    {
+        addressManager = _addressManager;
+    }
+
+    /// @dev The base contract ensures that the incoming message is from the contract _fxChild passed in the constructor.
+    /// The validateSender() makes sure that the contract on the root chain is the one relaying the message.
+    /// The root contract should have been set via setFxRootTunnel() after deployment
+    function _processMessageFromRoot(
+        uint256, /* stateId */
+        address sender,
+        bytes memory data
+    ) internal override validateSender(sender) {
+        // decode incoming data
+        (bytes32 syncType, bytes memory syncData) = abi.decode(
+            data,
+            (bytes32, bytes)
+        );
+
+        if (syncType == REGISTER) {
+            _registerNft(syncData);
+        } else if (syncType == DE_REGISTER) {
+            _deRegisterNft(syncData);
+        } else {
+            revert("ERR MSG");
+        }
+    }
+
+    /// @dev Handler for messages coming from the L1 when an owner wants to register
+    function _registerNft(bytes memory syncData) internal {
+        // Decode the params from the data
+        (
+            address owner,
+            address nftContractAddress,
+            uint256 nftId,
+            address creatorAddress,
+            uint256 optionBits
+        ) = abi.decode(syncData, (address, address, uint256, address, uint256));
+
+        // Call the registrar and register the NFT
+        addressManager.makerRegistrar().registerNftFromBridge(
+            owner,
+            nftContractAddress,
+            nftId,
+            creatorAddress,
+            optionBits
+        );
+    }
+
+    /// @dev Handler for messages coming from the L1 when an owner wants to de-register
+    function _deRegisterNft(bytes memory syncData) internal {
+        // Decode the params from the data
+        (address owner, address nftContractAddress, uint256 nftId) = abi.decode(
+            syncData,
+            (address, address, uint256)
+        );
+
+        addressManager.makerRegistrar().deRegisterNftFromBridge(
+            owner,
+            nftContractAddress,
+            nftId
+        );
+    }
+}

--- a/contracts/Bridge/RootRegistrar.sol
+++ b/contracts/Bridge/RootRegistrar.sol
@@ -1,0 +1,73 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@maticnetwork/fx-portal/contracts/tunnel/FxBaseRootTunnel.sol";
+import "../Maker/NftOwnership.sol";
+
+/// @dev This contract lives on the L1 and allows NFT owners to register NFTs that live on the L1.
+/// Once ownership is verified, it will send a message up to the contracts on the L2 specifying that
+/// the NFT has been registered or unregistered.
+/// This is not an upgradeable contract and should not be used with a proxy.
+contract RootRegistrar is FxBaseRootTunnel {
+    bytes32 public constant REGISTER = keccak256("REGISTER");
+    bytes32 public constant DE_REGISTER = keccak256("DE_REGISTER");
+
+    /// @param _checkpointManager This is a well known contract deployed by matic that is used to verify messages coming from the L2 down to L1.
+    /// @param _fxRoot This is a well known contract deployed by matic that will emit the events going from L1 to L2.
+    /// @dev You must call setFxChildTunnel() with the ChildRegistrar address on the L2 after deployment
+    constructor(address _checkpointManager, address _fxRoot)
+        FxBaseRootTunnel(_checkpointManager, _fxRoot)
+    {}
+
+    /// @dev Allows a NFT owner to register the NFT in the protocol on L1
+    /// Once the ownership is verified a message will be sent to the Child contract
+    /// on the L2 chain that will trigger a registration there.
+    function registerNft(
+        address nftContractAddress,
+        uint256 nftId,
+        address creatorAddress,
+        uint256 optionBits
+    ) external {
+        // Verify ownership
+        require(
+            NftOwnership._verifyOwnership(
+                nftContractAddress,
+                nftId,
+                msg.sender
+            ),
+            "NFT not owned"
+        );
+
+        // REGISTER, encode(nftContractAddress, nftId, creatorAddress, optionBits)
+        bytes memory message = abi.encode(
+            REGISTER,
+            abi.encode(nftContractAddress, nftId, creatorAddress, optionBits)
+        );
+        _sendMessageToChild(message);
+    }
+
+    /// @dev Allows a NFT owner to de-register the NFT in the protocol on L1
+    /// Once the ownership is verified a message will be sent to the Child contract
+    /// on the L2 chain that will trigger a desgregistration there.
+    function deRegisterNft(address nftContractAddress, uint256 nftId) external {
+        // Verify ownership
+        require(
+            NftOwnership._verifyOwnership(
+                nftContractAddress,
+                nftId,
+                msg.sender
+            ),
+            "NFT not owned"
+        );
+
+        // REGISTER, encode(address owner, address nftContractAddress, uint256 nftId)
+        bytes memory message = abi.encode(
+            DE_REGISTER,
+            abi.encode(msg.sender, nftContractAddress, nftId)
+        );
+        _sendMessageToChild(message);
+    }
+
+    /// @dev NOOP - No messages come from L2 down to L1
+    function _processMessageFromChild(bytes memory data) internal override {}
+}

--- a/contracts/Config/AddressManager.sol
+++ b/contracts/Config/AddressManager.sol
@@ -76,4 +76,10 @@ contract AddressManager is Initializable, AddressManagerStorageV1 {
         require(address(_defaultCuratorVault) != address(0x0), ZERO_INPUT);
         defaultCuratorVault = _defaultCuratorVault;
     }
+
+    /// @dev Setter for the L2 bridge registrar
+    function setChildRegistrar(address _childRegistrar) external onlyAdmin {
+        require(address(_childRegistrar) != address(0x0), ZERO_INPUT);
+        childRegistrar = _childRegistrar;
+    }
 }

--- a/contracts/Config/AddressManagerStorage.sol
+++ b/contracts/Config/AddressManagerStorage.sol
@@ -33,6 +33,9 @@ abstract contract AddressManagerStorageV1 is IAddressManager {
 
     /// @dev Local reference to the default curator vault
     ICuratorVault public defaultCuratorVault;
+
+    /// @dev Local reference to the L2 bridge registrar
+    address public childRegistrar;
 }
 
 /// On the next version of the protocol, if new variables are added, put them in the below

--- a/contracts/Config/IAddressManager.sol
+++ b/contracts/Config/IAddressManager.sol
@@ -46,4 +46,10 @@ interface IAddressManager {
     /// @dev Setter for the default Curator Vault contract address
     function setDefaultCuratorVault(ICuratorVault _defaultCuratorVault)
         external;
+
+    /// @dev Getter for the L2 bridge registrar
+    function childRegistrar() external returns (address);
+
+    /// @dev Setter for the L2 bridge registrar
+    function setChildRegistrar(address _childRegistrar) external;
 }

--- a/contracts/Maker/IMakerRegistrar.sol
+++ b/contracts/Maker/IMakerRegistrar.sol
@@ -19,4 +19,24 @@ interface IMakerRegistrar {
             address,
             address
         );
+
+    function verifyOwnership(
+        address nftContractAddress,
+        uint256 nftId,
+        address potentialOwner
+    ) external returns (bool);
+
+    function registerNftFromBridge(
+        address owner,
+        address nftContractAddress,
+        uint256 nftId,
+        address creatorAddress,
+        uint256 optionBits
+    ) external;
+
+    function deRegisterNftFromBridge(
+        address owner,
+        address nftContractAddress,
+        uint256 nftId
+    ) external;
 }

--- a/contracts/Maker/NftOwnership.sol
+++ b/contracts/Maker/NftOwnership.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
+
+/// @dev This is a library for other contracts to use that need to verify ownership of an NFT.
+/// Since this only has internal functions, it will be inlined into the calling contract at
+/// compile time and does not need to be separately deployed on chain.
+library NftOwnership {
+    /// @dev For the specified NFT, verify it is owned by the potential owner
+    function _verifyOwnership(
+        address nftContractAddress,
+        uint256 nftId,
+        address potentialOwner
+    ) internal view returns (bool) {
+        // TODO: support ERC721 + other custom contracts
+        uint256 balance = IERC1155Upgradeable(nftContractAddress).balanceOf(
+            potentialOwner,
+            nftId
+        );
+
+        return balance > 0;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
+    "@maticnetwork/fx-portal": "^1.0.4",
     "@openzeppelin/contracts-upgradeable": "^4.4.2",
     "@openzeppelin/hardhat-upgrades": "^1.13.0"
   }

--- a/test/Bridge/MakerRegistrar.ts
+++ b/test/Bridge/MakerRegistrar.ts
@@ -1,0 +1,75 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { ZERO_ADDRESS } from "../Scripts/constants";
+import { deploySystem } from "../Scripts/deploy";
+import { NOT_BRIDGE } from "../Scripts/errors";
+
+describe("AddressManager", function () {
+  it("Should get initialized with address manager", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { addressManager, childRegistrar } = await deploySystem(OWNER);
+
+    // Verify the role manager was set
+    const currentAddressManager = await childRegistrar.addressManager();
+    expect(currentAddressManager).to.equal(addressManager.address);
+  });
+
+  it("Should prevent non child registrar from registering or de-registering", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { makerRegistrar, testingStandard1155 } = await deploySystem(OWNER);
+
+    await expect(
+      makerRegistrar.registerNftFromBridge(
+        OWNER.address,
+        testingStandard1155.address,
+        "1",
+        ZERO_ADDRESS,
+        "0"
+      )
+    ).to.revertedWith(NOT_BRIDGE);
+
+    await expect(
+      makerRegistrar.deRegisterNftFromBridge(
+        OWNER.address,
+        testingStandard1155.address,
+        "1"
+      )
+    ).to.revertedWith(NOT_BRIDGE);
+  });
+
+  it("Should allow register and de-register via bridge", async function () {
+    const [OWNER, ALICE, BOB, CHILD] = await ethers.getSigners();
+    const { makerRegistrar, roleManager, testingStandard1155, addressManager } =
+      await deploySystem(OWNER);
+
+    // Mint an NFT to Alice
+    const NFT_ID = "1";
+    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
+    roleManager.grantRole(reactionMinterRole, OWNER.address);
+    testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
+
+    // Set child registrar address as the bridge so it can call the functions
+    await addressManager.setChildRegistrar(CHILD.address);
+
+    // Register the NFT from Alice's account and put Bob as the creator
+    // Verify event as well
+    await makerRegistrar
+      .connect(CHILD)
+      .registerNftFromBridge(
+        ALICE.address,
+        testingStandard1155.address,
+        NFT_ID,
+        BOB.address,
+        "0"
+      );
+
+    // De-register
+    await makerRegistrar
+      .connect(CHILD)
+      .deRegisterNftFromBridge(
+        ALICE.address,
+        testingStandard1155.address,
+        NFT_ID
+      );
+  });
+});

--- a/test/Config/AddressManager.ts
+++ b/test/Config/AddressManager.ts
@@ -145,4 +145,26 @@ describe("AddressManager", function () {
       addressManager.connect(ALICE).setReactionVault(BOB.address)
     ).to.revertedWith(NOT_ADMIN);
   });
+
+  it("Should allow owner to set child registrar address", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { addressManager } = await deploySystem(OWNER);
+
+    // Verify the setter checks invalid input
+    await expect(
+      addressManager.setChildRegistrar(ZERO_ADDRESS)
+    ).to.revertedWith(INVALID_ZERO_PARAM);
+
+    // Set it to Alice's address
+    await addressManager.setChildRegistrar(ALICE.address);
+
+    // Verify it got set
+    const currentVal = await addressManager.childRegistrar();
+    expect(currentVal).to.equal(ALICE.address);
+
+    // Verify non owner can't update address
+    await expect(
+      addressManager.connect(ALICE).setChildRegistrar(BOB.address)
+    ).to.revertedWith(NOT_ADMIN);
+  });
 });

--- a/test/Maker/MakerRegistrar.ts
+++ b/test/Maker/MakerRegistrar.ts
@@ -27,7 +27,7 @@ describe("MakerRegistrar", function () {
 
     // Since this is trying to register a non-existing NFT it should show the caller doesn't own it
     await expect(
-      makerRegistrar.registerNFT(
+      makerRegistrar.registerNft(
         testingStandard1155.address,
         "1",
         ZERO_ADDRESS,
@@ -51,13 +51,13 @@ describe("MakerRegistrar", function () {
     // Verify event as well
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(testingStandard1155.address, NFT_ID, BOB.address, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, BOB.address, "0");
 
     // Verify it can't be registered again now that it is registered
     await expect(
       makerRegistrar
         .connect(ALICE)
-        .registerNFT(testingStandard1155.address, NFT_ID, BOB.address, "0")
+        .registerNft(testingStandard1155.address, NFT_ID, BOB.address, "0")
     ).to.revertedWith(ALREADY_REGISTERED);
   });
 
@@ -87,7 +87,7 @@ describe("MakerRegistrar", function () {
     await expect(
       makerRegistrar
         .connect(ALICE)
-        .registerNFT(
+        .registerNft(
           testingStandard1155.address,
           NFT_ID,
           BOB.address,
@@ -135,7 +135,7 @@ describe("MakerRegistrar", function () {
 
     // Since this is trying to deregister a non-existing NFT it should show the caller doesn't own it
     await expect(
-      makerRegistrar.deregisterNFT(testingStandard1155.address, "1")
+      makerRegistrar.deregisterNft(testingStandard1155.address, "1")
     ).to.revertedWith(NFT_NOT_OWNED);
   });
 
@@ -154,13 +154,13 @@ describe("MakerRegistrar", function () {
     await expect(
       makerRegistrar
         .connect(ALICE)
-        .deregisterNFT(testingStandard1155.address, NFT_ID)
+        .deregisterNft(testingStandard1155.address, NFT_ID)
     ).to.revertedWith(NFT_NOT_FOUND);
 
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(testingStandard1155.address, NFT_ID, BOB.address, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, BOB.address, "0");
 
     // First NFT in the system should have source ID of 1
     const EXPECTED_SOURCE_ID = "1";
@@ -169,7 +169,7 @@ describe("MakerRegistrar", function () {
     await expect(
       makerRegistrar
         .connect(ALICE)
-        .deregisterNFT(testingStandard1155.address, NFT_ID)
+        .deregisterNft(testingStandard1155.address, NFT_ID)
     )
       .to.emit(makerRegistrar, "Deregistered")
       .withArgs(
@@ -183,7 +183,7 @@ describe("MakerRegistrar", function () {
     await expect(
       makerRegistrar
         .connect(ALICE)
-        .deregisterNFT(testingStandard1155.address, NFT_ID)
+        .deregisterNft(testingStandard1155.address, NFT_ID)
     ).to.revertedWith(NFT_NOT_REGISTERED);
 
     // Verify the flag was set to false

--- a/test/Reaction/ReactionVaultBuy.ts
+++ b/test/Reaction/ReactionVaultBuy.ts
@@ -57,7 +57,7 @@ describe("ReactionVault Buy", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(testingStandard1155.address, NFT_ID, ZERO_ADDRESS, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, ZERO_ADDRESS, "0");
 
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
       testingStandard1155.address,
@@ -73,7 +73,7 @@ describe("ReactionVault Buy", function () {
     // Unregister it
     await makerRegistrar
       .connect(ALICE)
-      .deregisterNFT(testingStandard1155.address, NFT_ID);
+      .deregisterNft(testingStandard1155.address, NFT_ID);
 
     // Now verify reactions can't be purchased
     await expect(
@@ -107,7 +107,7 @@ describe("ReactionVault Buy", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(testingStandard1155.address, NFT_ID, ZERO_ADDRESS, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, ZERO_ADDRESS, "0");
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
@@ -168,7 +168,7 @@ describe("ReactionVault Buy", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(testingStandard1155.address, NFT_ID, CREATOR.address, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, CREATOR.address, "0");
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
@@ -315,7 +315,7 @@ describe("ReactionVault Buy", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(testingStandard1155.address, NFT_ID, CREATOR.address, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, CREATOR.address, "0");
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(

--- a/test/Reaction/ReactionVaultRewards.ts
+++ b/test/Reaction/ReactionVaultRewards.ts
@@ -32,7 +32,7 @@ describe("ReactionVault Withdraw ERC20", function () {
     // Register it
     await makerRegistrar
       .connect(MAKER)
-      .registerNFT(testingStandard1155.address, NFT_ID, CREATOR.address, "0");
+      .registerNft(testingStandard1155.address, NFT_ID, CREATOR.address, "0");
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(

--- a/test/Reaction/ReactionVaultSell.ts
+++ b/test/Reaction/ReactionVaultSell.ts
@@ -79,7 +79,7 @@ describe("ReactionVault Sell", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(
+      .registerNft(
         testingStandard1155.address,
         MAKER_NFT_ID,
         CREATOR.address,
@@ -228,7 +228,7 @@ describe("ReactionVault Sell", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(
+      .registerNft(
         testingStandard1155.address,
         MAKER_NFT_ID,
         CREATOR.address,
@@ -330,7 +330,7 @@ describe("ReactionVault Sell", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(
+      .registerNft(
         testingStandard1155.address,
         MAKER_NFT_ID,
         CREATOR.address,
@@ -444,7 +444,7 @@ describe("ReactionVault Sell", function () {
     // Register it
     await makerRegistrar
       .connect(ALICE)
-      .registerNFT(
+      .registerNft(
         testingStandard1155.address,
         MAKER_NFT_ID,
         CREATOR.address,

--- a/test/Scripts/deploy.ts
+++ b/test/Scripts/deploy.ts
@@ -117,6 +117,17 @@ const deploySystem = async (owner: SignerWithAddress) => {
   ]);
   const curatorVault = CuratorVaultFactory.attach(deployedCuratorVault.address);
 
+  // Deploy the Child Registrar on the current chain.
+  // Note that this is not a proxy contract.
+  const ChildRegistrarFactory = await ethers.getContractFactory(
+    "ChildRegistrar"
+  );
+  // FX Child address is from Mumbai - see https://github.com/fx-portal/contracts
+  const childRegistrar = await ChildRegistrarFactory.deploy(
+    "0xCf73231F28B7331BBe3124B907840A94851f9f11",
+    addressManager.address
+  );
+
   // Update address manager
   await addressManager.setRoleManager(roleManager.address);
   await addressManager.setParameterManager(parameterManager.address);
@@ -124,6 +135,7 @@ const deploySystem = async (owner: SignerWithAddress) => {
   await addressManager.setReactionNftContract(reactionNFT1155.address);
   await addressManager.setReactionVault(reactionVault.address);
   await addressManager.setDefaultCuratorVault(curatorVault.address);
+  await addressManager.setChildRegistrar(childRegistrar.address);
 
   // Update permissions in the Role Manager
   // Reaction Vault should be allowed to mint reactions
@@ -146,6 +158,7 @@ const deploySystem = async (owner: SignerWithAddress) => {
   // Return objects for tests to use
   return {
     addressManager,
+    childRegistrar,
     curatorShares,
     curatorVault,
     makerRegistrar,

--- a/test/Scripts/errors.ts
+++ b/test/Scripts/errors.ts
@@ -6,6 +6,7 @@ const NFT_NOT_FOUND = "NFT not found";
 const NFT_NOT_OWNED = "NFT not owned";
 const NFT_NOT_REGISTERED = "NFT not registered";
 const NOT_ADMIN = "Not Admin";
+const NOT_BRIDGE = "Not Bridge";
 const NOT_CURATOR_VAULT = "Not CuratorVault";
 const NOT_REACTION_VAULT = "Not ReactionVault";
 const NO_BALANCE = "ERC20: transfer amount exceeds balance";
@@ -23,6 +24,7 @@ export {
   NFT_NOT_OWNED,
   NFT_NOT_REGISTERED,
   NOT_ADMIN,
+  NOT_BRIDGE,
   NOT_CURATOR_VAULT,
   NOT_REACTION_VAULT,
   NO_BALANCE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,6 +579,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@maticnetwork/fx-portal@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@maticnetwork/fx-portal/-/fx-portal-1.0.4.tgz#2274b02d4600b8ca40b06a0c9f7f1a788fff0496"
+  integrity sha512-z7K7blFgDJWCCaXTtqgqI20GDB0b4QIE8bmtxzijlbpSEziJsQMulJVZYVubAB2f/HNDObXE+i/jkpqSDxkC2A==
+  dependencies:
+    "@openzeppelin/contracts" "^4.2.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -630,6 +637,11 @@
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.2.tgz#748a5986a02548ef541cabc2ce8c67a890044c40"
   integrity sha512-bavxs18L47EmcdnL9I6DzsVSUJO+0/zD6zH7/6qG7QRBugvR3VNVZR+nMvuZlCNwuTTnCa3apR00PYzYr/efAw==
+
+"@openzeppelin/contracts@^4.2.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
+  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
 "@openzeppelin/hardhat-upgrades@^1.13.0":
   version "1.13.0"


### PR DESCRIPTION
This PR adds `ChildRegistrar` and `RootRegistrar` contracts.

Root registrar lives on the L1 and allows L1 NFT owners to register an NFT.  The contract verifies ownership and submits a message to the bridge.

On L2 the Child registrar receives the message and registers the NFT to the owner address.

Note that neither of these contracts support upgrading so they will be deployed like a standard contract.  If they need to be upgraded, they can be re-deployed and addresses updated in the app.  They hold no state or funds so this shouldn't be a problem.

This PR includes some refactor work.
* Changes the NFT ownership verification to a library to be reused across contracts
* Consistent Camel Case of "Nft" in code.

Also note that unit testing the bridge logic is a little bit tricky so we will need to manually test this.