### PR TITLE
Add chain ID for NFTs

### DIFF
--- a/contracts/Bridge/ChildRegistrar.sol
+++ b/contracts/Bridge/ChildRegistrar.sol
@@ -52,15 +52,20 @@ contract ChildRegistrar is FxBaseChildTunnel {
         // Decode the params from the data
         (
             address owner,
+            uint256 chainId,
             address nftContractAddress,
             uint256 nftId,
             address creatorAddress,
             uint256 optionBits
-        ) = abi.decode(syncData, (address, address, uint256, address, uint256));
+        ) = abi.decode(
+                syncData,
+                (address, uint256, address, uint256, address, uint256)
+            );
 
         // Call the registrar and register the NFT
         addressManager.makerRegistrar().registerNftFromBridge(
             owner,
+            chainId,
             nftContractAddress,
             nftId,
             creatorAddress,
@@ -71,13 +76,16 @@ contract ChildRegistrar is FxBaseChildTunnel {
     /// @dev Handler for messages coming from the L1 when an owner wants to de-register
     function _deRegisterNft(bytes memory syncData) internal {
         // Decode the params from the data
-        (address owner, address nftContractAddress, uint256 nftId) = abi.decode(
-            syncData,
-            (address, address, uint256)
-        );
+        (
+            address owner,
+            uint256 chainId,
+            address nftContractAddress,
+            uint256 nftId
+        ) = abi.decode(syncData, (address, uint256, address, uint256));
 
         addressManager.makerRegistrar().deRegisterNftFromBridge(
             owner,
+            chainId,
             nftContractAddress,
             nftId
         );

--- a/contracts/Bridge/RootRegistrar.sol
+++ b/contracts/Bridge/RootRegistrar.sol
@@ -38,10 +38,17 @@ contract RootRegistrar is FxBaseRootTunnel {
             "NFT not owned"
         );
 
-        // REGISTER, encode(nftContractAddress, nftId, creatorAddress, optionBits)
+        // REGISTER, encode(owner, chainId, nftContractAddress, nftId, creatorAddress, optionBits)
         bytes memory message = abi.encode(
             REGISTER,
-            abi.encode(nftContractAddress, nftId, creatorAddress, optionBits)
+            abi.encode(
+                msg.sender,
+                block.chainid,
+                nftContractAddress,
+                nftId,
+                creatorAddress,
+                optionBits
+            )
         );
         _sendMessageToChild(message);
     }
@@ -60,10 +67,10 @@ contract RootRegistrar is FxBaseRootTunnel {
             "NFT not owned"
         );
 
-        // REGISTER, encode(address owner, address nftContractAddress, uint256 nftId)
+        // DERegister, encode(address owner, uint256 chainId, address nftContractAddress, uint256 nftId)
         bytes memory message = abi.encode(
             DE_REGISTER,
-            abi.encode(msg.sender, nftContractAddress, nftId)
+            abi.encode(msg.sender, block.chainid, nftContractAddress, nftId)
         );
         _sendMessageToChild(message);
     }

--- a/contracts/Maker/IMakerRegistrar.sol
+++ b/contracts/Maker/IMakerRegistrar.sol
@@ -28,6 +28,7 @@ interface IMakerRegistrar {
 
     function registerNftFromBridge(
         address owner,
+        uint256 chainId,
         address nftContractAddress,
         uint256 nftId,
         address creatorAddress,
@@ -36,6 +37,7 @@ interface IMakerRegistrar {
 
     function deRegisterNftFromBridge(
         address owner,
+        uint256 chainId,
         address nftContractAddress,
         uint256 nftId
     ) external;

--- a/contracts/Maker/MakerRegistrarStorage.sol
+++ b/contracts/Maker/MakerRegistrarStorage.sol
@@ -20,8 +20,9 @@ abstract contract MakerRegistrarStorageV1 is IMakerRegistrar {
     /// De-registering and re-registering should use the existing source ID
     uint256 public sourceCount;
 
-    /// @dev Mapping to look up source ID from NFT address and ID
-    mapping(address => mapping(uint256 => uint256)) public nftToSourceLookup;
+    /// @dev Mapping to look up source ID from chain ID, NFT address, and ID
+    mapping(uint256 => mapping(address => mapping(uint256 => uint256)))
+        public nftToSourceLookup;
 
     /// @dev Mapping to look up source ID from meta ID key
     mapping(uint256 => uint256) public override metaToSourceLookup;

--- a/contracts/Maker/NftOwnership.sol
+++ b/contracts/Maker/NftOwnership.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
 
-/// @dev This is a library for other contracts to use that need to verify ownership of an NFT.
+/// @dev This is a library for other contracts to use that need to verify ownership of an NFT on the current chain.
 /// Since this only has internal functions, it will be inlined into the calling contract at
 /// compile time and does not need to be separately deployed on chain.
 library NftOwnership {

--- a/contracts/Reactions/ReactionVault.sol
+++ b/contracts/Reactions/ReactionVault.sol
@@ -68,6 +68,7 @@ contract ReactionVault is
 
     /// @dev Event emitted when curator vault rewards are granted to a taker
     event TakerRewardsGranted(
+        uint256 takerNftChainId,
         address takerNftAddress,
         uint256 takerNftId,
         address curatorVault,
@@ -272,6 +273,7 @@ contract ReactionVault is
     }
 
     /// @dev Allows a reaction NFT owner to spend (burn) their tokens at a specific target Taker NFT.
+    /// @param takerNftChainId Chain ID where the NFT lives
     /// @param takerNftAddress Target contract where the reaction is targeting
     /// @param takerNftId Target NFT ID in the contract
     /// @param reactionMetaId Reaction to spend
@@ -280,6 +282,7 @@ contract ReactionVault is
     /// @param curatorVaultOverride Optional address of non-default curator vault
     /// @param metaDataHash Optional hash of any metadata being associated with spend action
     function spendReaction(
+        uint256 takerNftChainId,
         address takerNftAddress,
         uint256 takerNftId,
         uint256 reactionMetaId,
@@ -378,13 +381,25 @@ contract ReactionVault is
             address(this)
         );
 
+        // Build a hash of the rewards params
+        uint256 rewardsIndex = uint256(
+            keccak256(
+                abi.encode(
+                    takerNftChainId,
+                    takerNftAddress,
+                    takerNftId,
+                    address(info.curatorVault.curatorShares()),
+                    curatorTokenId
+                )
+            )
+        );
+
         // Allocate rewards for the future NFT Owner
-        nftOwnerRewards[takerNftAddress][takerNftId][
-            address(info.curatorVault.curatorShares())
-        ][curatorTokenId] += info.takerCuratorShares;
+        nftOwnerRewards[rewardsIndex] += info.takerCuratorShares;
 
         // Emit event
         emit TakerRewardsGranted(
+            takerNftChainId,
             takerNftAddress,
             takerNftId,
             address(info.curatorVault),

--- a/contracts/Reactions/ReactionVaultStorage.sol
+++ b/contracts/Reactions/ReactionVaultStorage.sol
@@ -28,9 +28,8 @@ contract ReactionVaultStorageV1 is IReactionVault {
         public reactionPriceDetailsMapping;
 
     /// @dev tracks the rewards owed to an NFT owner in an 1155 token
-    /// NftAddress -> NftId -> RewardToken -> RewardTokenId -> balance
-    mapping(address => mapping(uint256 => mapping(address => mapping(uint256 => uint256))))
-        public nftOwnerRewards;
+    /// Hash(NftChainId, NftAddress, NftId, RewardTokenAddress, RewardTokenId) -> balance
+    mapping(uint256 => uint256) public nftOwnerRewards;
 }
 
 /// On the next version of the protocol, if new variables are added, put them in the below

--- a/test/Bridge/MakerRegistrar.ts
+++ b/test/Bridge/MakerRegistrar.ts
@@ -17,10 +17,12 @@ describe("Bridge Registrar", function () {
   it("Should prevent non child registrar from registering or de-registering", async function () {
     const [OWNER] = await ethers.getSigners();
     const { makerRegistrar, testingStandard1155 } = await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     await expect(
       makerRegistrar.registerNftFromBridge(
         OWNER.address,
+        chainId,
         testingStandard1155.address,
         "1",
         ZERO_ADDRESS,
@@ -31,6 +33,7 @@ describe("Bridge Registrar", function () {
     await expect(
       makerRegistrar.deRegisterNftFromBridge(
         OWNER.address,
+        chainId,
         testingStandard1155.address,
         "1"
       )
@@ -41,6 +44,7 @@ describe("Bridge Registrar", function () {
     const [OWNER, ALICE, BOB, CHILD] = await ethers.getSigners();
     const { makerRegistrar, roleManager, testingStandard1155, addressManager } =
       await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
@@ -57,6 +61,7 @@ describe("Bridge Registrar", function () {
       .connect(CHILD)
       .registerNftFromBridge(
         ALICE.address,
+        chainId,
         testingStandard1155.address,
         NFT_ID,
         BOB.address,
@@ -68,6 +73,7 @@ describe("Bridge Registrar", function () {
       .connect(CHILD)
       .deRegisterNftFromBridge(
         ALICE.address,
+        chainId,
         testingStandard1155.address,
         NFT_ID
       );

--- a/test/Maker/MakerRegistrar.ts
+++ b/test/Maker/MakerRegistrar.ts
@@ -95,6 +95,7 @@ describe("MakerRegistrar", function () {
     const [OWNER, ALICE, BOB] = await ethers.getSigners();
     const { makerRegistrar, roleManager, testingStandard1155 } =
       await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
@@ -126,6 +127,7 @@ describe("MakerRegistrar", function () {
     )
       .to.emit(makerRegistrar, "Registered")
       .withArgs(
+        chainId,
         testingStandard1155.address,
         BigNumber.from(NFT_ID),
         ALICE.address,
@@ -139,6 +141,7 @@ describe("MakerRegistrar", function () {
     // Verify source id from nft param
     expect(
       await makerRegistrar.nftToSourceLookup(
+        chainId,
         testingStandard1155.address,
         NFT_ID
       )
@@ -173,6 +176,7 @@ describe("MakerRegistrar", function () {
     const [OWNER, ALICE, BOB] = await ethers.getSigners();
     const { makerRegistrar, testingStandard1155, roleManager } =
       await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
@@ -203,6 +207,7 @@ describe("MakerRegistrar", function () {
     )
       .to.emit(makerRegistrar, "Deregistered")
       .withArgs(
+        chainId,
         testingStandard1155.address,
         BigNumber.from(NFT_ID),
         ALICE.address,

--- a/test/Reaction/ReactionVaultBuy.ts
+++ b/test/Reaction/ReactionVaultBuy.ts
@@ -35,6 +35,7 @@ describe("ReactionVault Buy", function () {
     const [OWNER, ALICE] = await ethers.getSigners();
     const { reactionVault, testingStandard1155, makerRegistrar, roleManager } =
       await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Trying to buy a reaction for a unknown NFT should fail
     await expect(
@@ -60,6 +61,7 @@ describe("ReactionVault Buy", function () {
       .registerNft(testingStandard1155.address, NFT_ID, ZERO_ADDRESS, "0");
 
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
+      chainId,
       testingStandard1155.address,
       NFT_ID
     );
@@ -96,6 +98,7 @@ describe("ReactionVault Buy", function () {
       roleManager,
       paymentTokenErc20,
     } = await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
@@ -111,6 +114,7 @@ describe("ReactionVault Buy", function () {
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
+      chainId,
       testingStandard1155.address,
       NFT_ID
     );
@@ -157,6 +161,7 @@ describe("ReactionVault Buy", function () {
       paymentTokenErc20,
       reactionNFT1155,
     } = await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
@@ -172,6 +177,7 @@ describe("ReactionVault Buy", function () {
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
+      chainId,
       testingStandard1155.address,
       NFT_ID
     );
@@ -301,6 +307,7 @@ describe("ReactionVault Buy", function () {
       paymentTokenErc20,
       reactionNFT1155,
     } = await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Buying 15 reactions in this test
     const REACTION_AMOUNT = BigNumber.from(15);
@@ -319,6 +326,7 @@ describe("ReactionVault Buy", function () {
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
+      chainId,
       testingStandard1155.address,
       NFT_ID
     );

--- a/test/Reaction/ReactionVaultRewards.ts
+++ b/test/Reaction/ReactionVaultRewards.ts
@@ -21,6 +21,7 @@ describe("ReactionVault Withdraw ERC20", function () {
       roleManager,
       paymentTokenErc20,
     } = await deploySystem(OWNER);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
 
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
@@ -36,6 +37,7 @@ describe("ReactionVault Withdraw ERC20", function () {
 
     // Get the NFT source ID
     const NFT_SOURCE_ID = await makerRegistrar.nftToSourceLookup(
+      chainId,
       testingStandard1155.address,
       NFT_ID
     );

--- a/test/Scripts/derivedParams.ts
+++ b/test/Scripts/derivedParams.ts
@@ -37,3 +37,23 @@ export const deriveReactionNftMetaId = (
   );
   return ethers.utils.keccak256(encodedParams);
 };
+
+export const deriveTakerRewardsKey = (
+  takerNftChainId: number,
+  takerNftAddress: string,
+  takerNftId: BigNumber,
+  curatorSharesAddress: string,
+  curatorSharesId: BigNumber
+) => {
+  const encodedParams = ethers.utils.defaultAbiCoder.encode(
+    ["uint256", "address", "uint256", "address", "uint256"],
+    [
+      takerNftChainId,
+      takerNftAddress,
+      takerNftId,
+      curatorSharesAddress,
+      curatorSharesId,
+    ]
+  );
+  return ethers.utils.keccak256(encodedParams);
+};


### PR DESCRIPTION
This PR allows us to store chain IDs in relation to both Maker and Taker NFTs.  This will prevent someone from possibly having an NFT contract conflict across chains.

Changes
* The register NFT call now includes the current chain in the params
* The bridge register NFT call now submits that in the data payload across layers
* Source ID for registered NFTs now includes chain ID
* Taker NFT rewards are now indexed via a hash of all params rather than a 6 deep nested mapping


Question: Should we get rid of the Source ID and just have that be a hash of the Chain + NFT Address + NFT ID?