### PR TITLE
Refactor NFT source ID to derived value

### DIFF
--- a/contracts/Maker/MakerRegistrarStorage.sol
+++ b/contracts/Maker/MakerRegistrarStorage.sol
@@ -16,14 +16,6 @@ abstract contract MakerRegistrarStorageV1 is IMakerRegistrar {
     /// @dev prefix used in meta ID generation
     string public constant MAKER_META_PREFIX = "MAKER";
 
-    /// @dev An incrementing unique number assigned to each NFT that is registered.
-    /// De-registering and re-registering should use the existing source ID
-    uint256 public sourceCount;
-
-    /// @dev Mapping to look up source ID from chain ID, NFT address, and ID
-    mapping(uint256 => mapping(address => mapping(uint256 => uint256)))
-        public nftToSourceLookup;
-
     /// @dev Mapping to look up source ID from meta ID key
     mapping(uint256 => uint256) public override metaToSourceLookup;
 

--- a/contracts/Reactions/ReactionVault.sol
+++ b/contracts/Reactions/ReactionVault.sol
@@ -634,7 +634,6 @@ contract ReactionVault is
             takerNftAddress,
             takerNftId
         );
-        require(info.sourceId > 0, "NFT not found");
 
         // Get the details about the NFT
         (

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -34,7 +34,7 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 
 const config: HardhatUserConfig = {
   solidity: '0.8.9',
-  defaultNetwork,
+  // defaultNetwork,
   // gasReporter: {
   //   currency: 'USD',
   //   coinmarketcap:

--- a/test/Maker/MakerRegistrar.ts
+++ b/test/Maker/MakerRegistrar.ts
@@ -7,7 +7,6 @@ import { deriveMakerNftMetaId } from "../Scripts/derivedParams";
 import {
   ALREADY_REGISTERED,
   INVALID_MAKER_BP,
-  NFT_NOT_FOUND,
   NFT_NOT_OWNED,
   NFT_NOT_REGISTERED,
 } from "../Scripts/errors";
@@ -155,14 +154,14 @@ describe("MakerRegistrar", function () {
     roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
+    // Get the source ID from the lookup
+    const EXPECTED_SOURCE_ID = await makerRegistrar.nftToSourceLookup(chainId, testingStandard1155.address, NFT_ID);
+
     // Encode the params and hash it to get the meta URI
     const derivedMetaId = deriveMakerNftMetaId(
-      BigNumber.from(1),
+      EXPECTED_SOURCE_ID,
       BigNumber.from(0)
     );
-
-    // First one registered should have source ID 1
-    const EXPECTED_SOURCE_ID = "1";
 
     // Register the NFT from Alice's account and put Bob as the creator
     // Verify event as well
@@ -242,15 +241,15 @@ describe("MakerRegistrar", function () {
       makerRegistrar
         .connect(ALICE)
         .deregisterNft(testingStandard1155.address, NFT_ID)
-    ).to.revertedWith(NFT_NOT_FOUND);
+    ).to.revertedWith(NFT_NOT_REGISTERED);
 
     // Register it
     await makerRegistrar
       .connect(ALICE)
       .registerNft(testingStandard1155.address, NFT_ID, BOB.address, TEST_SALE_CREATOR_BP, "0");
 
-    // First NFT in the system should have source ID of 1
-    const EXPECTED_SOURCE_ID = "1";
+    // Get the source ID from the lookup
+    const EXPECTED_SOURCE_ID = await makerRegistrar.nftToSourceLookup(chainId, testingStandard1155.address, NFT_ID);
 
     // Deregister it and check event params
     await expect(

--- a/test/Reaction/ReactionTakerRewards.ts
+++ b/test/Reaction/ReactionTakerRewards.ts
@@ -15,7 +15,6 @@ import {
   deriveTakerRewardsKey,
 } from "../Scripts/derivedParams";
 import {
-  NFT_NOT_FOUND,
   NFT_NOT_OWNED,
   NFT_NOT_REGISTERED,
   NO_REWARDS,
@@ -163,7 +162,7 @@ describe("ReactionVault Taker Rewards", function () {
           curatorVault.address,
           curatorShareId
         )
-    ).to.be.revertedWith(NFT_NOT_FOUND);
+    ).to.be.revertedWith(NFT_NOT_REGISTERED);
 
     // Mint the NFT to the taker
     testingStandard1155.mint(TAKER.address, TAKER_NFT_ID, "1", [0]);

--- a/test/Scripts/errors.ts
+++ b/test/Scripts/errors.ts
@@ -3,7 +3,6 @@ const INVALID_CURATOR_VAULT = "Err CuratorVault";
 const INVALID_MAKER_BP = "Invalid creator bp";
 const INVALID_ROLE_MANAGER = "RM invalid";
 const INVALID_ZERO_PARAM = "Invalid 0 input";
-const NFT_NOT_FOUND = "NFT not found";
 const NFT_NOT_OWNED = "NFT not owned";
 const NFT_NOT_REGISTERED = "NFT not registered";
 const NOT_ADMIN = "Not Admin";
@@ -24,7 +23,6 @@ export {
   INVALID_MAKER_BP,
   INVALID_ROLE_MANAGER,
   INVALID_ZERO_PARAM,
-  NFT_NOT_FOUND,
   NFT_NOT_OWNED,
   NFT_NOT_REGISTERED,
   NOT_ADMIN,


### PR DESCRIPTION
This PR changes the Source ID for an NFT from an incrementing number to a hashed value so it can be pre-determined.

Small change... let me know if you think there is value in having the source ID be a smaller number that we can understand with human a readable value instead of a 256 bit number.   This matches how we are storing other IDs though.