### PR TITLE
Role manager refactor

### DIFF
--- a/contracts/Config/AddressManager.sol
+++ b/contracts/Config/AddressManager.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 contract AddressManager is Initializable, AddressManagerStorageV1 {
     /// @dev Verifies with the role manager that the calling address has ADMIN role
     modifier onlyAdmin() {
-        require(roleManager.isAdmin(msg.sender), "Not Admin");
+        require(roleManager.isAddressManagerAdmin(msg.sender), "Not Admin");
         _;
     }
 
@@ -57,15 +57,6 @@ contract AddressManager is Initializable, AddressManagerStorageV1 {
     {
         require(address(_reactionNftContract) != address(0x0), ZERO_INPUT);
         reactionNftContract = _reactionNftContract;
-    }
-
-    /// @dev Setter for the maker registrar address
-    function setReactionVault(IReactionVault _reactionVault)
-        external
-        onlyAdmin
-    {
-        require(address(_reactionVault) != address(0x0), ZERO_INPUT);
-        reactionVault = _reactionVault;
     }
 
     /// @dev Setter for the default curator vault address

--- a/contracts/Config/AddressManagerStorage.sol
+++ b/contracts/Config/AddressManagerStorage.sol
@@ -28,9 +28,6 @@ abstract contract AddressManagerStorageV1 is IAddressManager {
     /// @dev Local reference to the reaction NFT contract
     IStandard1155 public reactionNftContract;
 
-    /// @dev Local reference to the reaction vault
-    IReactionVault public reactionVault;
-
     /// @dev Local reference to the default curator vault
     ICuratorVault public defaultCuratorVault;
 

--- a/contracts/Config/IAddressManager.sol
+++ b/contracts/Config/IAddressManager.sol
@@ -34,12 +34,6 @@ interface IAddressManager {
     function setReactionNftContract(IStandard1155 _reactionNftContract)
         external;
 
-    /// @dev Getter for the reaction Vault contract address
-    function reactionVault() external returns (IReactionVault);
-
-    /// @dev Setter for the reaction Vault contract address
-    function setReactionVault(IReactionVault _reactionVault) external;
-
     /// @dev Getter for the default Curator Vault contract address
     function defaultCuratorVault() external returns (ICuratorVault);
 

--- a/contracts/Parameters/ParameterManager.sol
+++ b/contracts/Parameters/ParameterManager.sol
@@ -9,7 +9,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 contract ParameterManager is Initializable, ParameterManagerStorageV1 {
     /// @dev Verifies with the role manager that the calling address has ADMIN role
     modifier onlyAdmin() {
-        require(addressManager.roleManager().isAdmin(msg.sender), "Not Admin");
+        require(
+            addressManager.roleManager().isParameterManagerAdmin(msg.sender),
+            "Not Admin"
+        );
         _;
     }
 

--- a/contracts/PermanentCuratorVault/PermanentCuratorVault.sol
+++ b/contracts/PermanentCuratorVault/PermanentCuratorVault.sol
@@ -22,10 +22,10 @@ contract PermanentCuratorVault is
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     /// @dev verifies that the calling address is the reaction vault
-    modifier onlyReactionVault() {
+    modifier onlyCuratorVaultPurchaser() {
         require(
-            address(addressManager.reactionVault()) == msg.sender,
-            "Not ReactionVault"
+            addressManager.roleManager().isCuratorVaultPurchaser(msg.sender),
+            "Not Admin"
         );
         _;
     }
@@ -96,7 +96,7 @@ contract PermanentCuratorVault is
         IERC20Upgradeable paymentToken,
         uint256 paymentAmount,
         address mintToAddress
-    ) external onlyReactionVault returns (uint256) {
+    ) external onlyCuratorVaultPurchaser returns (uint256) {
         // Get the curator share token ID
         uint256 curatorShareTokenId = _getTokenId(
             nftChainId,

--- a/contracts/PermanentCuratorVault/Shares/CuratorShares1155.sol
+++ b/contracts/PermanentCuratorVault/Shares/CuratorShares1155.sol
@@ -8,10 +8,10 @@ import "../../Token/Standard1155.sol";
 /// Only the Curator Vault can mint or burn shares
 contract CuratorShares1155 is Standard1155 {
     /// @dev verifies that the calling account is the curator vault
-    modifier onlyCuratorVault() {
+    modifier onlyCuratorShareAdmin() {
         require(
-            address(addressManager.defaultCuratorVault()) == msg.sender,
-            "Not CuratorVault"
+            addressManager.roleManager().isCuratorSharesAdmin(msg.sender),
+            "Not Admin"
         );
         _;
     }
@@ -22,7 +22,7 @@ contract CuratorShares1155 is Standard1155 {
         uint256 id,
         uint256 amount,
         bytes memory data
-    ) external onlyCuratorVault {
+    ) external onlyCuratorShareAdmin {
         _mint(to, id, amount, data);
     }
 
@@ -31,7 +31,7 @@ contract CuratorShares1155 is Standard1155 {
         address from,
         uint256 id,
         uint256 amount
-    ) external onlyCuratorVault {
+    ) external onlyCuratorShareAdmin {
         _burn(from, id, amount);
     }
 }

--- a/contracts/Permissions/IRoleManager.sol
+++ b/contracts/Permissions/IRoleManager.sol
@@ -2,21 +2,42 @@
 pragma solidity 0.8.9;
 
 interface IRoleManager {
-    /// @dev Determines if the specified address has permission to mint Reaction NFTs
-    /// @param potentialAddress Address to check
-    function isReactionMinter(address potentialAddress)
-        external
-        view
-        returns (bool);
-
-    /// @dev Determines if the specified address has permission to burn Reaction NFTs
-    /// @param potentialAddress Address to check
-    function isReactionBurner(address potentialAddress)
-        external
-        view
-        returns (bool);
-
-    /// @dev Determines if the specified address is an admin account
+    /// @dev Determines if the specified address has capability to mint and burn reaction NFTs
     /// @param potentialAddress Address to check
     function isAdmin(address potentialAddress) external view returns (bool);
+
+    /// @dev Determines if the specified address has permission to udpate addresses in the protocol
+    /// @param potentialAddress Address to check
+    function isAddressManagerAdmin(address potentialAddress)
+        external
+        view
+        returns (bool);
+
+    /// @dev Determines if the specified address has permission to update parameters in the protocol
+    /// @param potentialAddress Address to check
+    function isParameterManagerAdmin(address potentialAddress)
+        external
+        view
+        returns (bool);
+
+    /// @dev Determines if the specified address has permission to to mint and burn reaction NFTs
+    /// @param potentialAddress Address to check
+    function isReactionNftAdmin(address potentialAddress)
+        external
+        view
+        returns (bool);
+
+    /// @dev Determines if the specified address has permission to purchase curator vaults shares
+    /// @param potentialAddress Address to check
+    function isCuratorVaultPurchaser(address potentialAddress)
+        external
+        view
+        returns (bool);
+
+    /// @dev Determines if the specified address has permission to mint and burn curator shares
+    /// @param potentialAddress Address to check
+    function isCuratorSharesAdmin(address potentialAddress)
+        external
+        view
+        returns (bool);
 }

--- a/contracts/Permissions/RoleManager.sol
+++ b/contracts/Permissions/RoleManager.sol
@@ -24,23 +24,53 @@ contract RoleManager is
         return hasRole(DEFAULT_ADMIN_ROLE, potentialAddress);
     }
 
-    /// @dev Determines if the specified address has permission to mint Reaction NFTs
+    /// @dev Determines if the specified address has permission to udpate addresses in the protocol
     /// @param potentialAddress Address to check
-    function isReactionMinter(address potentialAddress)
+    function isAddressManagerAdmin(address potentialAddress)
         external
         view
         returns (bool)
     {
-        return hasRole(REACTION_MINTER_ROLE, potentialAddress);
+        return hasRole(ADDRESS_MANAGER_ADMIN, potentialAddress);
     }
 
-    /// @dev Determines if the specified address has permission to burn Reaction NFTs
+    /// @dev Determines if the specified address has permission to update parameters in the protocol
     /// @param potentialAddress Address to check
-    function isReactionBurner(address potentialAddress)
+    function isParameterManagerAdmin(address potentialAddress)
         external
         view
         returns (bool)
     {
-        return hasRole(REACTION_BURNER_ROLE, potentialAddress);
+        return hasRole(PARAMETER_MANAGER_ADMIN, potentialAddress);
+    }
+
+    /// @dev Determines if the specified address has permission to to mint and burn reaction NFTs
+    /// @param potentialAddress Address to check
+    function isReactionNftAdmin(address potentialAddress)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(REACTION_NFT_ADMIN, potentialAddress);
+    }
+
+    /// @dev Determines if the specified address has permission to purchase curator vaults shares
+    /// @param potentialAddress Address to check
+    function isCuratorVaultPurchaser(address potentialAddress)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(CURATOR_VAULT_PURCHASER, potentialAddress);
+    }
+
+    /// @dev Determines if the specified address has permission to mint and burn curator shares
+    /// @param potentialAddress Address to check
+    function isCuratorSharesAdmin(address potentialAddress)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(CURATOR_SHARES_ADMIN, potentialAddress);
     }
 }

--- a/contracts/Permissions/RoleManagerStorage.sol
+++ b/contracts/Permissions/RoleManagerStorage.sol
@@ -7,13 +7,25 @@ pragma solidity 0.8.9;
 /// StorageManager to inherit from the later version.  This ensures there are no storage layout
 /// corruptions when upgrading.
 contract RoleManagerStorageV1 {
-    /// @dev role for granting capability to mint reactions
-    bytes32 public constant REACTION_MINTER_ROLE =
-        keccak256("REACTION_MINTER_ROLE");
+    /// @dev role for granting capability to udpate addresses in the protocol
+    bytes32 public constant ADDRESS_MANAGER_ADMIN =
+        keccak256("ADDRESS_MANAGER_ADMIN");
 
-    /// @dev role for granting capability to burn reactions
-    bytes32 public constant REACTION_BURNER_ROLE =
-        keccak256("REACTION_BURNER_ROLE");
+    /// @dev role for granting capability to update parameters in the protocol
+    bytes32 public constant PARAMETER_MANAGER_ADMIN =
+        keccak256("PARAMETER_MANAGER_ADMIN");
+
+    /// @dev role for granting capability to mint and burn reaction NFTs
+    bytes32 public constant REACTION_NFT_ADMIN =
+        keccak256("REACTION_NFT_ADMIN");
+
+    /// @dev role for granting capability to purchase curator vaults shares
+    bytes32 public constant CURATOR_VAULT_PURCHASER =
+        keccak256("CURATOR_VAULT_PURCHASER");
+
+    /// @dev role for granting capability to mint and burn curator shares
+    bytes32 public constant CURATOR_SHARES_ADMIN =
+        keccak256("CURATOR_SHARES_ADMIN");
 }
 
 /// On the next version of the protocol, if new variables are added, put them in the below

--- a/contracts/Reactions/NFT/ReactionNft1155.sol
+++ b/contracts/Reactions/NFT/ReactionNft1155.sol
@@ -9,16 +9,9 @@ import "../../Token/Standard1155.sol";
 /// Only the NFT Burner role can burn tokens
 contract ReactionNft1155 is Standard1155 {
     /// @dev verifies that the calling account has a role to enable minting tokens
-    modifier onlyMinter() {
+    modifier onlyNftAdmin() {
         IRoleManager roleManager = IRoleManager(addressManager.roleManager());
-        require(roleManager.isReactionMinter(msg.sender), "Not Minter");
-        _;
-    }
-
-    /// @dev verifies that the calling account has a role to enable burning tokens
-    modifier onlyBurner() {
-        IRoleManager roleManager = IRoleManager(addressManager.roleManager());
-        require(roleManager.isReactionBurner(msg.sender), "Not Burner");
+        require(roleManager.isReactionNftAdmin(msg.sender), "Not NFT Admin");
         _;
     }
 
@@ -28,7 +21,7 @@ contract ReactionNft1155 is Standard1155 {
         uint256 id,
         uint256 amount,
         bytes memory data
-    ) external onlyMinter {
+    ) external onlyNftAdmin {
         _mint(to, id, amount, data);
     }
 
@@ -37,7 +30,7 @@ contract ReactionNft1155 is Standard1155 {
         address from,
         uint256 id,
         uint256 amount
-    ) external onlyBurner {
+    ) external onlyNftAdmin {
         _burn(from, id, amount);
     }
 

--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -129,7 +129,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   await addressManager.setParameterManager(parameterManager.address);
   await addressManager.setMakerRegistrar(makerRegistrar.address);
   await addressManager.setReactionNftContract(reactionNFT1155.address);
-  await addressManager.setReactionVault(reactionVault.address);
   await addressManager.setDefaultCuratorVault(curatorVault.address);
 
   // Update permissions in the Role Manager

--- a/test/Bridge/MakerRegistrar.ts
+++ b/test/Bridge/MakerRegistrar.ts
@@ -49,8 +49,6 @@ describe("Bridge Registrar", function () {
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Set child registrar address as the bridge so it can call the functions

--- a/test/Config/AddressManager.ts
+++ b/test/Config/AddressManager.ts
@@ -42,7 +42,7 @@ describe("AddressManager", function () {
     ]);
 
     // Add Bob to the old Role manager
-    const adminRole = await roleManager.DEFAULT_ADMIN_ROLE();
+    const adminRole = await roleManager.ADDRESS_MANAGER_ADMIN();
     await roleManager.grantRole(adminRole, BOB.address);
 
     // Since Bob is an admin on the old one but not the new one, it should fail
@@ -121,28 +121,6 @@ describe("AddressManager", function () {
     // Verify non owner can't update address
     await expect(
       addressManager.connect(ALICE).setReactionNftContract(BOB.address)
-    ).to.revertedWith(NOT_ADMIN);
-  });
-
-  it("Should allow owner to set reaction Vault address", async function () {
-    const [OWNER, ALICE, BOB] = await ethers.getSigners();
-    const { addressManager } = await deploySystem(OWNER);
-
-    // Verify the setter checks invalid input
-    await expect(addressManager.setReactionVault(ZERO_ADDRESS)).to.revertedWith(
-      INVALID_ZERO_PARAM
-    );
-
-    // Set it to Alice's address
-    await addressManager.setReactionVault(ALICE.address);
-
-    // Verify it got set
-    const currentVal = await addressManager.reactionVault();
-    expect(currentVal).to.equal(ALICE.address);
-
-    // Verify non owner can't update address
-    await expect(
-      addressManager.connect(ALICE).setReactionVault(BOB.address)
     ).to.revertedWith(NOT_ADMIN);
   });
 

--- a/test/Maker/MakerRegistrar.ts
+++ b/test/Maker/MakerRegistrar.ts
@@ -44,8 +44,6 @@ describe("MakerRegistrar", function () {
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register the NFT from Alice's account and put Bob as the creator
@@ -99,8 +97,6 @@ describe("MakerRegistrar", function () {
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Verify anything over 100% is rejected (10_000 bp is 100%)
@@ -150,8 +146,6 @@ describe("MakerRegistrar", function () {
     // Mint an NFT to Alice
     const NFT_ID = "1";
     const OPTION_BITS = "0";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Get the source ID from the lookup
@@ -232,8 +226,6 @@ describe("MakerRegistrar", function () {
 
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Verify NFT unknown in the system can't be deregsitered

--- a/test/Permissions/RoleManager.ts
+++ b/test/Permissions/RoleManager.ts
@@ -22,7 +22,7 @@ describe("RoleManager", function () {
     expect(result).to.equal(false);
   });
 
-  it("Should allow owner to set Reaction Minter", async function () {
+  it("Should allow owner to set address manager", async function () {
     // eslint-disable-next-line no-unused-vars
     const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
 
@@ -35,31 +35,32 @@ describe("RoleManager", function () {
     // This attach call is just for typings on the object (not necessary but helpful)
     const manager = RoleManagerFactory.attach(deployedManager.address);
 
-    const reactionMinterRole = await manager.REACTION_MINTER_ROLE();
+    const role = await manager.ADDRESS_MANAGER_ADMIN();
 
     // Verify bob does not haver permission
-    let result = await manager.hasRole(reactionMinterRole, BOB.address);
+    let result = await manager.hasRole(role, BOB.address);
     expect(result).to.equal(false);
 
     // Add BOB
-    await manager.grantRole(reactionMinterRole, BOB.address);
+    await manager.grantRole(role, BOB.address);
 
     // Verify it was set
-    result = await manager.isReactionMinter(BOB.address);
+    result = await manager.isAddressManagerAdmin(BOB.address);
     expect(result).to.equal(true);
 
     // Verify a non owner (ALICE) can't set the permission
     await expect(
-      manager.connect(ALICE).grantRole(reactionMinterRole, CAROL.address)
+      manager.connect(ALICE).grantRole(role, CAROL.address)
     ).to.be.reverted;
 
     // Remove BOB and verify
-    await manager.revokeRole(reactionMinterRole, BOB.address);
-    result = await manager.isReactionMinter(BOB.address);
+    await manager.revokeRole(role, BOB.address);
+    result = await manager.isAddressManagerAdmin(BOB.address);
     expect(result).to.equal(false);
   });
 
-  it("Should allow owner to set Reaction Burner", async function () {
+
+  it("Should allow owner to set parameter manager", async function () {
     // eslint-disable-next-line no-unused-vars
     const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
 
@@ -72,27 +73,142 @@ describe("RoleManager", function () {
     // This attach call is just for typings on the object (not necessary but helpful)
     const manager = RoleManagerFactory.attach(deployedManager.address);
 
-    const reactionBurnerRole = await manager.REACTION_BURNER_ROLE();
+    const role = await manager.PARAMETER_MANAGER_ADMIN();
 
     // Verify bob does not haver permission
-    let result = await manager.hasRole(reactionBurnerRole, BOB.address);
+    let result = await manager.hasRole(role, BOB.address);
     expect(result).to.equal(false);
 
     // Add BOB
-    await manager.grantRole(reactionBurnerRole, BOB.address);
+    await manager.grantRole(role, BOB.address);
 
     // Verify it was set
-    result = await manager.isReactionBurner(BOB.address);
+    result = await manager.isParameterManagerAdmin(BOB.address);
     expect(result).to.equal(true);
 
     // Verify a non owner (ALICE) can't set the permission
     await expect(
-      manager.connect(ALICE).grantRole(reactionBurnerRole, CAROL.address)
+      manager.connect(ALICE).grantRole(role, CAROL.address)
     ).to.be.reverted;
 
     // Remove BOB and verify
-    await manager.revokeRole(reactionBurnerRole, BOB.address);
-    result = await manager.isReactionBurner(BOB.address);
+    await manager.revokeRole(role, BOB.address);
+    result = await manager.isParameterManagerAdmin(BOB.address);
     expect(result).to.equal(false);
   });
+
+
+  it("Should allow owner to set reaction nft admin", async function () {
+    // eslint-disable-next-line no-unused-vars
+    const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
+
+    // Deploy the RoleManger using the upgrades plugin with a proxy
+    const RoleManagerFactory = await ethers.getContractFactory("RoleManager");
+    const deployedManager = await upgrades.deployProxy(RoleManagerFactory, [
+      OWNER.address,
+    ]);
+
+    // This attach call is just for typings on the object (not necessary but helpful)
+    const manager = RoleManagerFactory.attach(deployedManager.address);
+
+    const role = await manager.REACTION_NFT_ADMIN();
+
+    // Verify bob does not haver permission
+    let result = await manager.hasRole(role, BOB.address);
+    expect(result).to.equal(false);
+
+    // Add BOB
+    await manager.grantRole(role, BOB.address);
+
+    // Verify it was set
+    result = await manager.isReactionNftAdmin(BOB.address);
+    expect(result).to.equal(true);
+
+    // Verify a non owner (ALICE) can't set the permission
+    await expect(
+      manager.connect(ALICE).grantRole(role, CAROL.address)
+    ).to.be.reverted;
+
+    // Remove BOB and verify
+    await manager.revokeRole(role, BOB.address);
+    result = await manager.isReactionNftAdmin(BOB.address);
+    expect(result).to.equal(false);
+  });
+
+
+  it("Should allow owner to set curator vault purchaser", async function () {
+    // eslint-disable-next-line no-unused-vars
+    const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
+
+    // Deploy the RoleManger using the upgrades plugin with a proxy
+    const RoleManagerFactory = await ethers.getContractFactory("RoleManager");
+    const deployedManager = await upgrades.deployProxy(RoleManagerFactory, [
+      OWNER.address,
+    ]);
+
+    // This attach call is just for typings on the object (not necessary but helpful)
+    const manager = RoleManagerFactory.attach(deployedManager.address);
+
+    const role = await manager.CURATOR_VAULT_PURCHASER();
+
+    // Verify bob does not haver permission
+    let result = await manager.hasRole(role, BOB.address);
+    expect(result).to.equal(false);
+
+    // Add BOB
+    await manager.grantRole(role, BOB.address);
+
+    // Verify it was set
+    result = await manager.isCuratorVaultPurchaser(BOB.address);
+    expect(result).to.equal(true);
+
+    // Verify a non owner (ALICE) can't set the permission
+    await expect(
+      manager.connect(ALICE).grantRole(role, CAROL.address)
+    ).to.be.reverted;
+
+    // Remove BOB and verify
+    await manager.revokeRole(role, BOB.address);
+    result = await manager.isCuratorVaultPurchaser(BOB.address);
+    expect(result).to.equal(false);
+  });
+
+
+  it("Should allow owner to set curator shares admin", async function () {
+    // eslint-disable-next-line no-unused-vars
+    const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
+
+    // Deploy the RoleManger using the upgrades plugin with a proxy
+    const RoleManagerFactory = await ethers.getContractFactory("RoleManager");
+    const deployedManager = await upgrades.deployProxy(RoleManagerFactory, [
+      OWNER.address,
+    ]);
+
+    // This attach call is just for typings on the object (not necessary but helpful)
+    const manager = RoleManagerFactory.attach(deployedManager.address);
+
+    const role = await manager.CURATOR_SHARES_ADMIN();
+
+    // Verify bob does not haver permission
+    let result = await manager.hasRole(role, BOB.address);
+    expect(result).to.equal(false);
+
+    // Add BOB
+    await manager.grantRole(role, BOB.address);
+
+    // Verify it was set
+    result = await manager.isCuratorSharesAdmin(BOB.address);
+    expect(result).to.equal(true);
+
+    // Verify a non owner (ALICE) can't set the permission
+    await expect(
+      manager.connect(ALICE).grantRole(role, CAROL.address)
+    ).to.be.reverted;
+
+    // Remove BOB and verify
+    await manager.revokeRole(role, BOB.address);
+    result = await manager.isCuratorSharesAdmin(BOB.address);
+    expect(result).to.equal(false);
+  });
+
 });

--- a/test/Reaction/ReactionBuyAndSpend.ts
+++ b/test/Reaction/ReactionBuyAndSpend.ts
@@ -38,8 +38,6 @@ describe("ReactionVault Buy", function () {
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register it
@@ -128,8 +126,6 @@ describe("ReactionVault Buy", function () {
     // Buying 10 reactions
     const REACTION_AMOUNT = BigNumber.from(10);
 
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register it

--- a/test/Reaction/ReactionNftTokens.ts
+++ b/test/Reaction/ReactionNftTokens.ts
@@ -27,7 +27,7 @@ describe("Reaction1155 Token", function () {
     ).to.be.reverted;
 
     // Grant authorization to Bob
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
+    const reactionMinterRole = await roleManager.REACTION_NFT_ADMIN();
     roleManager.grantRole(reactionMinterRole, BOB.address);
 
     // Mint again

--- a/test/Reaction/ReactionTakerRewards.ts
+++ b/test/Reaction/ReactionTakerRewards.ts
@@ -35,8 +35,6 @@ describe("ReactionVault Taker Rewards", function () {
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(MAKER.address, NFT_ID, "1", [0]);
 
     // Verify withdrawing rewards for unknown Taker NFT fails
@@ -70,8 +68,6 @@ describe("ReactionVault Taker Rewards", function () {
     // Mint an NFT to Alice
     const MAKER_NFT_ID = "1";
     const TAKER_NFT_ID = "2";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, MAKER_NFT_ID, "1", [0]);
 
     // Register it
@@ -279,8 +275,6 @@ describe("ReactionVault Taker Rewards", function () {
     // Mint an NFT to Alice
     const MAKER_NFT_ID = "1";
     const TAKER_NFT_ID = "2";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, MAKER_NFT_ID, "1", [0]);
 
     // Register it

--- a/test/Reaction/ReactionVaultBuy.ts
+++ b/test/Reaction/ReactionVaultBuy.ts
@@ -51,8 +51,6 @@ describe("ReactionVault Buy", function () {
     // Now register and unregister an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register it
@@ -103,8 +101,6 @@ describe("ReactionVault Buy", function () {
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register it
@@ -178,8 +174,6 @@ describe("ReactionVault Buy", function () {
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register it
@@ -329,8 +323,6 @@ describe("ReactionVault Buy", function () {
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, NFT_ID, "1", [0]);
 
     // Register it

--- a/test/Reaction/ReactionVaultRewards.ts
+++ b/test/Reaction/ReactionVaultRewards.ts
@@ -26,8 +26,6 @@ describe("ReactionVault Withdraw ERC20", function () {
     // Now register an NFT and get the Meta ID
     // Mint an NFT to Alice
     const NFT_ID = "1";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(MAKER.address, NFT_ID, "1", [0]);
 
     // Register it

--- a/test/Reaction/ReactionVaultSell.ts
+++ b/test/Reaction/ReactionVaultSell.ts
@@ -79,8 +79,6 @@ describe("ReactionVault Sell", function () {
     // Mint an NFT to Alice
     const MAKER_NFT_ID = "1";
     const TAKER_NFT_ID = "2";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, MAKER_NFT_ID, "1", [0]);
 
     // Register it
@@ -237,8 +235,6 @@ describe("ReactionVault Sell", function () {
     // Mint an NFT to Alice
     const MAKER_NFT_ID = "1";
     const TAKER_NFT_ID = "2";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, MAKER_NFT_ID, "1", [0]);
 
     // Register it
@@ -343,8 +339,6 @@ describe("ReactionVault Sell", function () {
     // Mint an NFT to Alice
     const MAKER_NFT_ID = "1";
     const TAKER_NFT_ID = "2";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, MAKER_NFT_ID, "1", [0]);
 
     // Register it
@@ -461,8 +455,6 @@ describe("ReactionVault Sell", function () {
     // Mint an NFT to Alice
     const MAKER_NFT_ID = "1";
     const TAKER_NFT_ID = "2";
-    const reactionMinterRole = await roleManager.REACTION_MINTER_ROLE();
-    roleManager.grantRole(reactionMinterRole, OWNER.address);
     testingStandard1155.mint(ALICE.address, MAKER_NFT_ID, "1", [0]);
 
     // Register it

--- a/test/Scripts/deploy.ts
+++ b/test/Scripts/deploy.ts
@@ -136,21 +136,26 @@ const deploySystem = async (owner: SignerWithAddress) => {
     addressManager.address
   );
 
+  // Update permissions in the Role Manager
+  // Owner can update addresses
+  await roleManager.grantRole(await roleManager.ADDRESS_MANAGER_ADMIN(), owner.address);
+  // Owner can update parameters
+  await roleManager.grantRole(await roleManager.PARAMETER_MANAGER_ADMIN(), owner.address);
+  // Reaction Vault can mint/burn reactions
+  await roleManager.grantRole(await roleManager.REACTION_NFT_ADMIN(), reactionVault.address);
+  // Reaction Vault can purchase curator shares
+  await roleManager.grantRole(await roleManager.CURATOR_VAULT_PURCHASER(), reactionVault.address);
+  // Curator Vault can mint/burn curator shares
+  await roleManager.grantRole(await roleManager.CURATOR_SHARES_ADMIN(), curatorVault.address);
+
   // Update address manager
   await addressManager.setRoleManager(roleManager.address);
   await addressManager.setParameterManager(parameterManager.address);
   await addressManager.setMakerRegistrar(makerRegistrar.address);
   await addressManager.setReactionNftContract(reactionNFT1155.address);
-  await addressManager.setReactionVault(reactionVault.address);
+
   await addressManager.setDefaultCuratorVault(curatorVault.address);
   await addressManager.setChildRegistrar(childRegistrar.address);
-
-  // Update permissions in the Role Manager
-  // Reaction Vault should be allowed to mint reactions
-  const minterRole = await roleManager.REACTION_MINTER_ROLE();
-  await roleManager.grantRole(minterRole, reactionVault.address);
-  const burnerRole = await roleManager.REACTION_BURNER_ROLE();
-  await roleManager.grantRole(burnerRole, reactionVault.address);
 
   // Update the Parameters in the protocol
   await parameterManager.setPaymentToken(paymentTokenErc20.address);

--- a/test/Scripts/errors.ts
+++ b/test/Scripts/errors.ts
@@ -7,8 +7,6 @@ const NFT_NOT_OWNED = "NFT not owned";
 const NFT_NOT_REGISTERED = "NFT not registered";
 const NOT_ADMIN = "Not Admin";
 const NOT_BRIDGE = "Not Bridge";
-const NOT_CURATOR_VAULT = "Not CuratorVault";
-const NOT_REACTION_VAULT = "Not ReactionVault";
 const NO_BALANCE = "ERC20: transfer amount exceeds balance";
 const NO_REWARDS = "No rewards";
 const NO_TOKENS_TO_BURN = "ERC1155: burn amount exceeds balance";
@@ -27,8 +25,6 @@ export {
   NFT_NOT_REGISTERED,
   NOT_ADMIN,
   NOT_BRIDGE,
-  NOT_CURATOR_VAULT,
-  NOT_REACTION_VAULT,
   NO_BALANCE,
   NO_REWARDS,
   NO_TOKENS_TO_BURN,


### PR DESCRIPTION
This PR moves to using the role manager for all function permission checks.

Previously, some of the permission checks were using the address manager to only allow certain addresses to make calls.  This changes it so that more than one address could make the call and permission checks are gated by roles instead.