### PR TITLE
QSP-3: Add warning about roles in comments

### DIFF
--- a/contracts/Config/AddressManager.sol
+++ b/contracts/Config/AddressManager.sol
@@ -5,6 +5,10 @@ import "./AddressManagerStorage.sol";
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
+/// @dev Note: This contract is protected via a permissioned account set in the role manager.  Caution should
+/// be used as the role owner could renounce the role leaving all future actions disabled.  Additionally,
+/// if a malicious account was able to obtain the role, they could use it to set values to malicious addresses.
+/// See the public documentation website for more details.
 contract AddressManager is Initializable, AddressManagerStorageV1 {
     /// @dev Verifies with the role manager that the calling address has ADMIN role
     modifier onlyAdmin() {

--- a/contracts/CuratorVault/Token/CuratorToken1155.sol
+++ b/contracts/CuratorVault/Token/CuratorToken1155.sol
@@ -6,6 +6,10 @@ import "../../Token/Standard1155.sol";
 /// @title CuratorToken1155
 /// @dev This contract will be used to track Curator Token ownership
 /// Only the Curator Vault can mint or burn tokens
+/// Note: This contract is protected via a permissioned account set in the role manager.  Caution should
+/// be used as the role owner could renounce the role leaving all future actions disabled.  Additionally,
+/// if a malicious account was able to obtain the role, they could use it to mint or burn tokens.
+/// See the public documentation website for more details.
 contract CuratorToken1155 is Standard1155 {
     /// @dev verifies that the calling account is the curator vault
     modifier onlyCuratorTokenAdmin() {

--- a/contracts/Parameters/ParameterManager.sol
+++ b/contracts/Parameters/ParameterManager.sol
@@ -6,6 +6,10 @@ import "../Config/IAddressManager.sol";
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
+/// @dev Note: This contract is protected via a permissioned account set in the role manager.  Caution should
+/// be used as the role owner could renounce the role leaving all future actions disabled.  Additionally,
+/// if a malicious account was able to obtain the role, they could use it to set values to malicious values.
+/// See the public documentation website for more details.
 contract ParameterManager is Initializable, ParameterManagerStorageV1 {
     /// @dev Verifies with the role manager that the calling address has ADMIN role
     modifier onlyAdmin() {

--- a/contracts/Permissions/RoleManager.sol
+++ b/contracts/Permissions/RoleManager.sol
@@ -7,6 +7,10 @@ import "./RoleManagerStorage.sol";
 
 /// @title RoleManager
 /// @dev This contract will track the roles and permissions in the RARA protocol
+/// Note: This contract is protected via a permissioned account set via the initializer.  Caution should
+/// be used as the owner could renounce the role leaving all future actions disabled.  Additionally,
+/// if a malicious account was able to obtain the role, they could use it to grant permissions to malicious accounts.
+/// See the public documentation website for more details.
 contract RoleManager is
     IRoleManager,
     AccessControlUpgradeable,

--- a/contracts/Reactions/NFT/ReactionNft1155.sol
+++ b/contracts/Reactions/NFT/ReactionNft1155.sol
@@ -7,6 +7,10 @@ import "../../Token/Standard1155.sol";
 /// @dev This contract will be used to track Reaction NFTs in the protocol.
 /// Only the NFT Minter role can mint tokens
 /// Only the NFT Burner role can burn tokens
+/// Note: This contract is protected via a permissioned account set in the role manager.  Caution should
+/// be used as the role owner could renounce the role leaving all future actions disabled.  Additionally,
+/// if a malicious account was able to obtain the role, they could use it to mint or burn reactions.
+/// See the public documentation website for more details.
 contract ReactionNft1155 is Standard1155 {
     /// @dev verifies that the calling account has a role to enable minting tokens
     modifier onlyNftAdmin() {

--- a/contracts/SigmoidCuratorVault/SigmoidCuratorVault.sol
+++ b/contracts/SigmoidCuratorVault/SigmoidCuratorVault.sol
@@ -16,6 +16,10 @@ import "./Curve/Sigmoid.sol";
 /// the shape of the sigmoid are set in the parameter manager.
 /// At any point in time the owners of the curator tokens can sell them back to the
 /// bonding curve.
+/// Note: This contract is protected via a permissioned account set in the role manager.  Caution should
+/// be used as the role owner could renounce the role leaving all future actions disabled.  Additionally,
+/// if a malicious account was able to obtain the role, they could use it to set values to malicious values.
+/// See the public documentation website for more details.
 contract SigmoidCuratorVault is
     ReentrancyGuardUpgradeable,
     Sigmoid,


### PR DESCRIPTION
This PR adds warnings about the role manager and the risks associated with it.  This PR should just be comments and no logic changes.