### PR TITLE
QSP-11: Duplicate overflow checks

### DIFF
--- a/contracts/SigmoidCuratorVault/Curve/ExtendedMath.sol
+++ b/contracts/SigmoidCuratorVault/Curve/ExtendedMath.sol
@@ -8,16 +8,10 @@ library ExtendedMath {
      * @return The given number raised to the power of 2
      */
     function pow2(int256 a) internal pure returns (int256) {
-        if (a == 0) {
-            return 0;
-        }
         return a * a;
     }
 
     function pow3(int256 a) internal pure returns (int256) {
-        if (a == 0) {
-            return 0;
-        }
         return a * a * a;
     }
 


### PR DESCRIPTION
Since solidity 0.8 checks for overflows on multiplication, there was no need for explicit checks.  This PR removes the unneeded require statements.

Also, the 0 check was not needed since the majority case is a non-zero value.