### PR TITLE
Add like token contract

### DIFF
--- a/contracts/Likes/Token/ILikeToken1155.sol
+++ b/contracts/Likes/Token/ILikeToken1155.sol
@@ -1,0 +1,11 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.9;
+
+/// @dev Interface for the LikeToken1155 toke contract.
+interface ILikeToken1155 {
+    /// @dev Allows a priviledged account to mint a token to the specified address
+    function mint(address to) external;
+
+    /// @dev Allows the owner to burn a token to from their address
+    function burn(uint256 id) external;
+}

--- a/contracts/Likes/Token/LikeToken1155.sol
+++ b/contracts/Likes/Token/LikeToken1155.sol
@@ -1,0 +1,72 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import "./ILikeToken1155.sol";
+import "./LikeToken1155Storage.sol";
+
+/// @title LikeToken1155
+/// @dev This contract implements the 1155 standard and tracks "Likes" in the RaRa platform.
+/// When a user reacts to a target NFT, they will be issued a like token.
+/// Only a single token per unique ID will ever be issued, and IDs will be incremented in an ascending counter,
+///   on each mint.  Only the reaction NFT admin can mint these tokens (Reaction Vault address).
+/// These tokens are non-transferrable.
+/// An owner may burn a token from their own wallet.
+contract LikeToken1155 is
+    ILikeToken1155,
+    ERC1155Upgradeable,
+    LikeToken1155StorageV1
+{
+    // Always minting and burning 1 token at a time
+    uint8 public constant TOKEN_AMOUNT = 1;
+
+    /// @dev initializer to call after deployment, can only be called once
+    function initialize(string memory _uri, address _addressManager)
+        public
+        initializer
+    {
+        __ERC1155_init(_uri);
+
+        addressManager = IAddressManager(_addressManager);
+    }
+
+    /// @dev verifies that the calling account has a role to enable minting tokens
+    modifier onlyReactionNftAdmin() {
+        IRoleManager roleManager = IRoleManager(addressManager.roleManager());
+        require(roleManager.isReactionNftAdmin(msg.sender), "Not NFT Admin");
+        _;
+    }
+
+    /// @dev Allows reaction minter role to mint a like token
+    function mint(address to) external onlyReactionNftAdmin {
+        // Increment the id counter
+        idCount = idCount + 1;
+
+        // Mint the token
+        _mint(to, idCount, TOKEN_AMOUNT, new bytes(0));
+    }
+
+    /// @dev Allows a like token holder to burn their own token
+    function burn(uint256 id) external {
+        // Burn the token (balance check will be done inside this call)
+        _burn(msg.sender, id, TOKEN_AMOUNT);
+    }
+
+    /// @dev Like Tokens are non-transferrable to other accounts.
+    function _beforeTokenTransfer(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal virtual override(ERC1155Upgradeable) {
+        super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+
+        // Only allow minting or burning.  Mints have "from address" of 0x0 and burns have "to address" of 0x0.
+        require(
+            from == address(0x0) || to == address(0x0),
+            "Like transfer restricted"
+        );
+    }
+}

--- a/contracts/Likes/Token/LikeToken1155Storage.sol
+++ b/contracts/Likes/Token/LikeToken1155Storage.sol
@@ -1,0 +1,22 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.9;
+
+import "../../Config/IAddressManager.sol";
+
+/// @title LikeToken1155StorageV1
+/// @dev This contract will hold all local variables for the LikeToken1155 Contract
+/// When upgrading the protocol, inherit from this contract on the V2 version and change the
+/// LikeToken1155 to inherit from the later version.  This ensures there are no storage layout
+/// corruptions when upgrading.
+contract LikeToken1155StorageV1 {
+    IAddressManager public addressManager;
+    uint256 public idCount;
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract LikeToken1155StorageV2 is LikeToken1155StorageV1 {
+  address newVariable;
+}
+ */

--- a/test/Likes/LikeToken.ts
+++ b/test/Likes/LikeToken.ts
@@ -1,0 +1,138 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+import { deploySystem } from "../Scripts/setup";
+import { TEST_NFT_URI } from "../Scripts/constants";
+import { LIKE_TRANSFER_RESTRICTED, NO_TOKENS_TO_BURN, REACTION_TRANSFER_RESTRICTED } from "../Scripts/errors";
+
+describe("LikeToken1155", function () {
+  it("Should get initialized with address manager", async function () {
+    const [OWNER] = await ethers.getSigners();
+    const { addressManager } = await deploySystem(OWNER);
+
+    const LikeToken1155Factory = await ethers.getContractFactory("LikeToken1155");
+    const deployedTest1155 = await upgrades.deployProxy(LikeToken1155Factory, [
+      TEST_NFT_URI,
+      addressManager.address,
+    ]);
+    const likeToken = LikeToken1155Factory.attach(deployedTest1155.address);
+
+    // Verify the address manager and uri are set
+    const setURI = await likeToken.uri(1);
+    expect(setURI).to.equal(TEST_NFT_URI);
+
+    const setAddressManager = await likeToken.addressManager();
+    expect(setAddressManager).to.equal(addressManager.address);
+  });
+
+  it("Should mint tokens if authorized", async function () {
+    const [OWNER, ALICE, BOB] = await ethers.getSigners();
+    const { addressManager, roleManager } = await deploySystem(OWNER);
+
+    const LikeToken1155Factory = await ethers.getContractFactory("LikeToken1155");
+    const deployedTest1155 = await upgrades.deployProxy(LikeToken1155Factory, [
+      TEST_NFT_URI,
+      addressManager.address,
+    ]);
+    const likeToken = LikeToken1155Factory.attach(deployedTest1155.address);
+
+    // Verify Bob's non-authorized acct can't mint
+    await expect(
+      likeToken.connect(BOB).mint(ALICE.address)
+    ).to.be.reverted;
+
+    // Grant authorization to Bob
+    const reactionMinterRole = await roleManager.REACTION_NFT_ADMIN();
+    roleManager.grantRole(reactionMinterRole, BOB.address);
+
+    // Mint again
+    await likeToken.connect(BOB).mint(ALICE.address);
+
+    // Verify balance
+    let balance = await likeToken.balanceOf(ALICE.address, "1");
+    expect(balance.toString()).to.equal("1");
+
+    // Verify transfer is restricted
+    await expect(
+      likeToken
+        .connect(ALICE)
+        .safeTransferFrom(ALICE.address, BOB.address, "1", "1", [0])
+    ).to.be.revertedWith(LIKE_TRANSFER_RESTRICTED);
+
+    // Verify Bob balance 
+    balance = await likeToken.balanceOf(BOB.address, "1");
+    expect(balance.toString()).to.equal("0");
+  });
+
+  it("Should increment token IDs", async function () {
+    const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
+    const { addressManager, roleManager } = await deploySystem(OWNER);
+
+    const LikeToken1155Factory = await ethers.getContractFactory("LikeToken1155");
+    const deployedTest1155 = await upgrades.deployProxy(LikeToken1155Factory, [
+      TEST_NFT_URI,
+      addressManager.address,
+    ]);
+    const likeToken = LikeToken1155Factory.attach(deployedTest1155.address);
+
+    // Grant authorization to Bob
+    const reactionMinterRole = await roleManager.REACTION_NFT_ADMIN();
+    roleManager.grantRole(reactionMinterRole, BOB.address);
+
+    // Mint 1
+    await likeToken.connect(BOB).mint(ALICE.address);
+    let balance = await likeToken.balanceOf(ALICE.address, "1");
+    expect(balance.toString()).to.equal("1");
+
+    // Mint 2
+    await likeToken.connect(BOB).mint(ALICE.address);
+    balance = await likeToken.balanceOf(ALICE.address, "2");
+    expect(balance.toString()).to.equal("1");
+
+    // Mint 3
+    await likeToken.connect(BOB).mint(CAROL.address);
+    balance = await likeToken.balanceOf(CAROL.address, "3");
+    expect(balance.toString()).to.equal("1");
+
+  });
+
+  it("Should burn owned tokens", async function () {
+    const [OWNER, ALICE, BOB, CAROL] = await ethers.getSigners();
+    const { addressManager, roleManager } = await deploySystem(OWNER);
+
+    const LikeToken1155Factory = await ethers.getContractFactory("LikeToken1155");
+    const deployedTest1155 = await upgrades.deployProxy(LikeToken1155Factory, [
+      TEST_NFT_URI,
+      addressManager.address,
+    ]);
+    const likeToken = LikeToken1155Factory.attach(deployedTest1155.address);
+
+    // Grant authorization to Bob
+    const reactionMinterRole = await roleManager.REACTION_NFT_ADMIN();
+    roleManager.grantRole(reactionMinterRole, BOB.address);
+
+    // Mint 1
+    await likeToken.connect(BOB).mint(ALICE.address);
+    let balance = await likeToken.balanceOf(ALICE.address, "1");
+    expect(balance.toString()).to.equal("1");
+
+    // Carol should not be able to burn the token she doesn't own
+    await expect(
+      likeToken
+        .connect(CAROL)
+        .burn("1")
+    ).to.be.revertedWith(NO_TOKENS_TO_BURN);
+
+    // Allow Alice to burn her own token
+    await likeToken.connect(ALICE).burn("1");
+    balance = await likeToken.balanceOf(ALICE.address, "1");
+    expect(balance.toString()).to.equal("0");
+
+    // Second time should fail
+    await expect(
+      likeToken
+        .connect(ALICE)
+        .burn("1")
+    ).to.be.revertedWith(NO_TOKENS_TO_BURN);
+  });
+
+});

--- a/test/Scripts/errors.ts
+++ b/test/Scripts/errors.ts
@@ -3,6 +3,7 @@ const INVALID_BP = "Invalid bp";
 const INVALID_CURATOR_VAULT = "Err CuratorVault";
 const INVALID_ROLE_MANAGER = "RM invalid";
 const INVALID_ZERO_PARAM = "Invalid 0 input";
+const LIKE_TRANSFER_RESTRICTED = "Like transfer restricted"
 const NFT_NOT_OWNED = "NFT not owned";
 const NFT_NOT_REGISTERED = "NFT not registered";
 const NOT_ADMIN = "Not Admin";
@@ -23,6 +24,7 @@ export {
   INVALID_CURATOR_VAULT,
   INVALID_ROLE_MANAGER,
   INVALID_ZERO_PARAM,
+  LIKE_TRANSFER_RESTRICTED,
   NFT_NOT_OWNED,
   NFT_NOT_REGISTERED,
   NOT_ADMIN,


### PR DESCRIPTION
This is the contract for Like Tokens.

* ERC1155
* Minting 1 token at a time with sequentially increasing IDs
* Minting is gated for the reaction vault only
* Non Transferrable
* Own can burn their token

Unit tests added to verify functionality.