### PR TITLE
Rename react methods

### DIFF
--- a/contracts/Reactions/ReactionVault.sol
+++ b/contracts/Reactions/ReactionVault.sol
@@ -575,7 +575,7 @@ contract ReactionVault is
 
     /// @dev Allows a user to react to content & receive a like token.
     /// If value is sent into this function then the user will purchase curation tokens.
-    function react(
+    function reactLegacy(
         uint256 transformId,
         uint256 quantity,
         address referrer,
@@ -629,7 +629,7 @@ contract ReactionVault is
     }
 
     /// @dev External method identical to _freeReaction()
-    function freeReact(
+    function react(
         uint256 transformId,
         uint256 optionBits,
         uint256 takerNftChainId,
@@ -662,7 +662,7 @@ contract ReactionVault is
         );
     }
 
-    function freeReactAsDispatcher(
+    function reactAsDispatcher(
         address reactor,
         uint256 transformId,
         uint256 optionBits,
@@ -708,7 +708,7 @@ contract ReactionVault is
 
     /// @dev Allows a user to react to content & receive a like token without sending any value.
     /// This function will allow the user to record their reaction on-chain and collect a "like" token but not purchase any curator tokens.
-    function freeReactWithSig(DataTypes.FreeReactWithSigData calldata vars)
+    function reactWithSig(DataTypes.ReactWithSigData calldata vars)
         external
         nonReentrant
     {

--- a/contracts/Reactions/ReactionVaultStorage.sol
+++ b/contracts/Reactions/ReactionVaultStorage.sol
@@ -33,10 +33,10 @@ contract ReactionVaultStorageV1 is IReactionVault {
 }
 
 contract ReactionVaultStorageV2 is ReactionVaultStorageV1 {
-    // Typehash for the freeReactWithSig method
+    // Typehash for the reactWithSig method
     bytes32 internal constant REACT_WITH_SIG_TYPEHASH =
         keccak256(
-            "FreeReactWithSig(address reactor,uint256 transformId,uint256 quantity,uint256 optionBits,uint256 takerNftChainId,address takerNftAddress,uint256 takerNftId,string ipfsMetadataHash,uint256 nonce,uint256 deadline)"
+            "ReactWithSig(address reactor,uint256 transformId,uint256 quantity,uint256 optionBits,uint256 takerNftChainId,address takerNftAddress,uint256 takerNftId,string ipfsMetadataHash,uint256 nonce,uint256 deadline)"
         );
 }
 

--- a/contracts/WithSig/DataTypes.sol
+++ b/contracts/WithSig/DataTypes.sol
@@ -16,7 +16,7 @@ library DataTypes {
         uint256 deadline;
     }
 
-    /// @notice A struct containing the parameters required for the `freeReactWithSig()` function.
+    /// @notice A struct containing the parameters required for the `reactWithSig()` function.
     ///         Parameters are almost the same as the regular `react()` function, with the reactor's (signer) address and an EIP712Signature added.
     /// @param reactor The reactor which is the message signer.
     /// @param transformId Internal id used to derive the reaction token id.
@@ -27,7 +27,7 @@ library DataTypes {
     /// @param takerNftId Target NFT ID in the contract
     /// @param ipfsMetadataHash Optional hash of any metadata being associated with spend action
     /// @param sig The EIP712Signature struct containing the follower's signature.
-    struct FreeReactWithSigData {
+    struct ReactWithSigData {
         address reactor;
         uint256 transformId;
         uint256 quantity;

--- a/test/AsDispatcher/ReactAsDispatcher.ts
+++ b/test/AsDispatcher/ReactAsDispatcher.ts
@@ -9,7 +9,7 @@ import {
 import {ZERO_ADDRESS} from "../Scripts/constants";
 import {NOT_ACCOUNT_HOLDER_OR_DISPATCHER} from "../Scripts/errors";
 
-describe("ReactionVault FreeReactAsDispatcher", function () {
+describe("ReactionVault ReactAsDispatcher", function () {
   it("Should issue a like token", async function () {
     const [OWNER, ALICE, BOB, DISPATCHER] = await ethers.getSigners();
     const {
@@ -46,7 +46,7 @@ describe("ReactionVault FreeReactAsDispatcher", function () {
     // Encode the params and hash it to get the meta URI
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
-    // Args for freeReactAsDispatcher
+    // Args for reactAsDispatcher
     const reactor = BOB.address;
     const transformId = TRANSFORM_ID;
     const quantity = 1;
@@ -59,7 +59,7 @@ describe("ReactionVault FreeReactAsDispatcher", function () {
     // From Bob's dispatcher, register a free reaction
     const tx = await reactionVault
       .connect(DISPATCHER)
-      .freeReactAsDispatcher(
+      .reactAsDispatcher(
         reactor,
         transformId,
         optionBits,
@@ -122,7 +122,7 @@ describe("ReactionVault FreeReactAsDispatcher", function () {
     // Encode the params and hash it to get the meta URI
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
-    // Args for freeReactAsDispatcher
+    // Args for reactAsDispatcher
     const reactor = BOB.address;
     const transformId = TRANSFORM_ID;
     const quantity = 1;
@@ -136,7 +136,7 @@ describe("ReactionVault FreeReactAsDispatcher", function () {
     await expect(
       reactionVault
         .connect(NON_DISPATCHER)
-        .freeReactAsDispatcher(
+        .reactAsDispatcher(
           reactor,
           transformId,
           optionBits,

--- a/test/Reaction/ReactionBuyAndSpend.ts
+++ b/test/Reaction/ReactionBuyAndSpend.ts
@@ -55,7 +55,7 @@ describe("ReactionVault Buy And Spend", function () {
     const metadataHash = "QmV288zHttJJwPBZAW3L922dBypWqukFNWzekT6chxW4Cu";
 
     // Buy and spend the reaction
-    const transaction = await reactionVault.react(
+    const transaction = await reactionVault.reactLegacy(
       REACTION_ID,
       REACTION_AMOUNT,
       REFERRER.address, // Referrer
@@ -137,7 +137,7 @@ describe("ReactionVault Buy And Spend", function () {
     const metadataHash = "QmV288zHttJJwPBZAW3L922dBypWqukFNWzekT6chxW4Cu";
 
     // Buy and spend the reaction
-    const transaction = await reactionVault.react(
+    const transaction = await reactionVault.reactLegacy(
       REACTION_ID,
       REACTION_AMOUNT,
       REFERRER.address, // Referrer

--- a/test/Reaction/ReactionVaultFree.ts
+++ b/test/Reaction/ReactionVaultFree.ts
@@ -17,7 +17,7 @@ describe("ReactionVault Free Reaction", function () {
 
     // Trying to buy a reaction for a unknown NFT should fail
     await expect(
-      reactionVault.react(
+      reactionVault.reactLegacy(
         123456, // uint256 transformId,
         1, // uint256 quantity,
         ZERO_ADDRESS, // address ,
@@ -70,7 +70,7 @@ describe("ReactionVault Free Reaction", function () {
 
     // verify unregistered transform
     await expect(
-      reactionVault.react(
+      reactionVault.reactLegacy(
         TRANSFORM_ID, // uint256 transformId,
         1, // uint256 quantity,
         ZERO_ADDRESS, // address ,
@@ -116,7 +116,7 @@ describe("ReactionVault Free Reaction", function () {
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
     // Reacting for free with a registered reaction should succeed
-    const tx = await reactionVault.connect(BOB).react(
+    const tx = await reactionVault.connect(BOB).reactLegacy(
       TRANSFORM_ID, // uint256 transformId,
       1, // uint256 quantity,
       ZERO_ADDRESS, // address ,
@@ -172,7 +172,7 @@ describe("ReactionVault Free Reaction", function () {
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
     // Reacting for free with a registered reaction should succeed
-    const tx = await reactionVault.connect(BOB).react(
+    const tx = await reactionVault.connect(BOB).reactLegacy(
       TRANSFORM_ID, // uint256 transformId,
       1, // uint256 quantity,
       ZERO_ADDRESS, // address ,
@@ -196,7 +196,7 @@ describe("ReactionVault Free Reaction", function () {
     // expect(tokenBalance).to.equal(1);
 
     // Reacting for money
-    const tx2 = await reactionVault.connect(ALICE).react(
+    const tx2 = await reactionVault.connect(ALICE).reactLegacy(
       TRANSFORM_ID, // uint256 transformId,
       1, // uint256 quantity,
       ZERO_ADDRESS, // address ,
@@ -215,7 +215,7 @@ describe("ReactionVault Free Reaction", function () {
     // expect(tokenBalance2).to.equal(1);
 
     // Reacting for free with a registered reaction should succeed
-    const tx3 = await reactionVault.connect(BOB).react(
+    const tx3 = await reactionVault.connect(BOB).reactLegacy(
       TRANSFORM_ID, // uint256 transformId,
       1, // uint256 quantity,
       ZERO_ADDRESS, // address ,
@@ -265,7 +265,7 @@ describe("ReactionVault Free Reaction", function () {
 
     // Send two reactions => should reject
     const tx = await expect(
-      reactionVault.connect(BOB).react(
+      reactionVault.connect(BOB).reactLegacy(
         TRANSFORM_ID, // uint256 transformId,
         2, // uint256 quantity,
         ZERO_ADDRESS, // address ,

--- a/test/WithSig/ReactWithSig.ts
+++ b/test/WithSig/ReactWithSig.ts
@@ -14,9 +14,9 @@ import {
   SIGNATURE_EXPIRED,
   SIGNATURE_INVALID,
 } from "../Scripts/errors";
-import {getFreeReactWithSigParts} from "../helpers/utils";
+import {getReactWithSigParts} from "../helpers/utils";
 
-describe("ReactionVault FreeReactWithSig", function () {
+describe("ReactionVault ReactWithSig", function () {
   it("Should reject unknown transform", async function () {
     const [OWNER, , BOB] = await ethers.getSigners();
     const {reactionVault, parameterManager} = await deploySystem(OWNER);
@@ -24,7 +24,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     // Sig retrieval vars
     const verifyingContract = reactionVault.address;
     const signer = BOB;
-    // Args for freeReactWithSig
+    // Args for reactWithSig
     const reactor = BOB.address;
     const transformId = 123456;
     const quantity = 1;
@@ -38,8 +38,8 @@ describe("ReactionVault FreeReactWithSig", function () {
     const nonce = (await parameterManager.sigNonces(signer.address)).toNumber();
     const deadline = MAX_UINT256;
 
-    // Produce a signature that can be passed to freeReactWithSig()
-    const signature = await getFreeReactWithSigParts(
+    // Produce a signature that can be passed to reactWithSig()
+    const signature = await getReactWithSigParts(
       signer,
       verifyingContract,
       reactor,
@@ -55,7 +55,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     );
 
     await expect(
-      reactionVault.connect(OWNER).freeReactWithSig({
+      reactionVault.connect(OWNER).reactWithSig({
         reactor,
         transformId,
         quantity,
@@ -117,7 +117,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     // Sig retrieval vars
     const verifyingContract = reactionVault.address;
     const signer = ALICE;
-    // Args for freeReactWithSig
+    // Args for reactWithSig
     const reactor = ALICE.address;
     const transformId = TRANSFORM_ID;
     const quantity = 1;
@@ -131,8 +131,8 @@ describe("ReactionVault FreeReactWithSig", function () {
     const nonce = (await parameterManager.sigNonces(signer.address)).toNumber();
     const deadline = MAX_UINT256;
 
-    // Produce a signature that can be passed to freeReactWithSig()
-    const signature = await getFreeReactWithSigParts(
+    // Produce a signature that can be passed to reactWithSig()
+    const signature = await getReactWithSigParts(
       signer,
       verifyingContract,
       reactor,
@@ -148,7 +148,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     );
 
     await expect(
-      reactionVault.connect(OWNER).freeReactWithSig({
+      reactionVault.connect(OWNER).reactWithSig({
         reactor,
         transformId,
         quantity,
@@ -197,12 +197,12 @@ describe("ReactionVault FreeReactWithSig", function () {
     // Encode the params and hash it to get the meta URI
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
-    // Define variables neeeded for a freeReactWithSig call on Bob's behalf
+    // Define variables neeeded for a reactWithSig call on Bob's behalf
     // ----------------------------------------------------------------
     // Sig retrieval vars
     const verifyingContract = reactionVault.address;
     const signer = BOB;
-    // Args for freeReactWithSig
+    // Args for reactWithSig
     const reactor = BOB.address;
     const transformId = TRANSFORM_ID;
     const quantity = 1;
@@ -215,8 +215,8 @@ describe("ReactionVault FreeReactWithSig", function () {
     const nonce = (await parameterManager.sigNonces(signer.address)).toNumber();
     const deadline = MAX_UINT256;
 
-    // Produce a signature that can be passed to freeReactWithSig()
-    const signature = await getFreeReactWithSigParts(
+    // Produce a signature that can be passed to reactWithSig()
+    const signature = await getReactWithSigParts(
       signer,
       verifyingContract,
       reactor,
@@ -232,7 +232,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     );
 
     await expect(
-      reactionVault.connect(OWNER).freeReactWithSig({
+      reactionVault.connect(OWNER).reactWithSig({
         reactor,
         transformId,
         quantity,
@@ -281,12 +281,12 @@ describe("ReactionVault FreeReactWithSig", function () {
     // Encode the params and hash it to get the meta URI
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
-    // Define variables neeeded for a freeReactWithSig call on Bob's behalf
+    // Define variables neeeded for a reactWithSig call on Bob's behalf
     // ----------------------------------------------------------------
     // Sig retrieval vars
     const verifyingContract = reactionVault.address;
     const signer = BOB;
-    // Args for freeReactWithSig
+    // Args for reactWithSig
     const reactor = BOB.address;
     const transformId = TRANSFORM_ID;
     const quantity = 1;
@@ -299,8 +299,8 @@ describe("ReactionVault FreeReactWithSig", function () {
     const nonce = (await parameterManager.sigNonces(signer.address)).toNumber();
     const deadline = MAX_UINT256;
 
-    // Produce a signature that can be passed to freeReactWithSig()
-    const signature = await getFreeReactWithSigParts(
+    // Produce a signature that can be passed to reactWithSig()
+    const signature = await getReactWithSigParts(
       signer,
       verifyingContract,
       reactor,
@@ -316,7 +316,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     );
 
     await expect(
-      reactionVault.connect(OWNER).freeReactWithSig({
+      reactionVault.connect(OWNER).reactWithSig({
         reactor,
         transformId,
         quantity,
@@ -366,12 +366,12 @@ describe("ReactionVault FreeReactWithSig", function () {
     // Encode the params and hash it to get the meta URI
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
-    // Define variables neeeded for a freeReactWithSig call on Bob's behalf
+    // Define variables neeeded for a reactWithSig call on Bob's behalf
     // ----------------------------------------------------------------
     // Sig retrieval vars
     const verifyingContract = reactionVault.address;
     const signer = BOB;
-    // Args for freeReactWithSig
+    // Args for reactWithSig
     const reactor = BOB.address;
     const transformId = TRANSFORM_ID;
     const quantity = 1;
@@ -384,8 +384,8 @@ describe("ReactionVault FreeReactWithSig", function () {
     const nonce = (await parameterManager.sigNonces(signer.address)).toNumber();
     const deadline = MAX_UINT256;
 
-    // Produce a signature that can be passed to freeReactWithSig()
-    const signature = await getFreeReactWithSigParts(
+    // Produce a signature that can be passed to reactWithSig()
+    const signature = await getReactWithSigParts(
       signer,
       verifyingContract,
       reactor,
@@ -400,7 +400,7 @@ describe("ReactionVault FreeReactWithSig", function () {
       deadline
     );
 
-    const tx = await reactionVault.connect(OWNER).freeReactWithSig({
+    const tx = await reactionVault.connect(OWNER).reactWithSig({
       reactor,
       transformId,
       quantity,
@@ -471,12 +471,12 @@ describe("ReactionVault FreeReactWithSig", function () {
     );
     const TRANSFORM_ID = deriveTransformId(NFT_SOURCE_ID, BigNumber.from(0));
 
-    // Define variables neeeded for a freeReactWithSig call on Bob's behalf
+    // Define variables neeeded for a reactWithSig call on Bob's behalf
     // ----------------------------------------------------------------
     // Sig retrieval vars
     const verifyingContract = reactionVault.address;
     const signer = BOB;
-    // Args for freeReactWithSig
+    // Args for reactWithSig
     const reactor = BOB.address;
     const transformId = TRANSFORM_ID;
     const quantity = 2; // invalid quantity
@@ -489,8 +489,8 @@ describe("ReactionVault FreeReactWithSig", function () {
     const nonce = (await parameterManager.sigNonces(signer.address)).toNumber();
     const deadline = MAX_UINT256;
 
-    // Produce a signature that can be passed to freeReactWithSig()
-    const signature = await getFreeReactWithSigParts(
+    // Produce a signature that can be passed to reactWithSig()
+    const signature = await getReactWithSigParts(
       signer,
       verifyingContract,
       reactor,
@@ -506,7 +506,7 @@ describe("ReactionVault FreeReactWithSig", function () {
     );
 
     await expect(
-      reactionVault.connect(OWNER).freeReactWithSig({
+      reactionVault.connect(OWNER).reactWithSig({
         reactor,
         transformId,
         quantity,

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -98,7 +98,7 @@ export async function getRemoveDispatcherWithSigParts(
   return await getSig(signer, msgParams);
 }
 
-const buildFreeReactWithSigParams = (
+const buildReactWithSigParams = (
   verifyingContract: string,
   reactor: string,
   transformId: BigNumberish,
@@ -112,7 +112,7 @@ const buildFreeReactWithSigParams = (
   deadline: string
 ) => ({
   types: {
-    FreeReactWithSig: [
+    ReactWithSig: [
       // Function ABI parts
       {name: "reactor", type: "address"},
       {name: "transformId", type: "uint256"},
@@ -142,7 +142,7 @@ const buildFreeReactWithSigParams = (
   },
 });
 
-export async function getFreeReactWithSigParts(
+export async function getReactWithSigParts(
   // signer
   signer: SignerWithAddress,
   // builder args
@@ -158,7 +158,7 @@ export async function getFreeReactWithSigParts(
   nonce: number,
   deadline: string
 ): Promise<{v: number; r: string; s: string}> {
-  const msgParams = buildFreeReactWithSigParams(
+  const msgParams = buildReactWithSigParams(
     verifyingContract,
     reactor,
     transformId,


### PR DESCRIPTION
Flagged the current react method as "legacy" code
`react` -> `reactLegacy`

Gave "free" reaction's premier status with the newly liberated "react" name
`freeReact` -> `react`
`freeReactWithSig` -> `reactWithSig`
`freeReactAsDispatcher` -> `reactAsDispatcher`

In a future where paid reactions become a favorable means of interacting with the protocol, we can explicitly describe their behavior with new method names
e.g.,  `reactAndPayCurator`, `reactAndPayCuratorWithSig`, `reactAndPayCuratorAsDispatcher`