### PR TITLE
Guard sig nonces

### DIFF
--- a/contracts/Parameters/ParameterManager.sol
+++ b/contracts/Parameters/ParameterManager.sol
@@ -21,6 +21,15 @@ contract ParameterManager is Initializable, ParameterManagerStorageV3 {
         _;
     }
 
+    /// @dev Verifies with the role manager that the calling address has NONCE_UPDATER role
+    modifier onlySigNonceUpdater() {
+        require(
+            addressManager.roleManager().isSigNonceUpdater(msg.sender),
+            "Not signature nonce updater"
+        );
+        _;
+    }
+
     /// @dev Events emitted on updates
     event PaymentTokenUpdated(IWMATIC newValue);
     event ReactionPriceUpdated(uint256 newValue);
@@ -126,7 +135,11 @@ contract ParameterManager is Initializable, ParameterManagerStorageV3 {
     }
 
     /// @dev Incrementer for an account's current EIP-712 signature nonce
-    function incSigNonceFor(address signer) external returns (uint256 nonce) {
+    function incSigNonceFor(address signer)
+        external
+        onlySigNonceUpdater
+        returns (uint256 nonce)
+    {
         // Returns the original nonce
         nonce = sigNonces[signer];
         uint256 incrementedNonce = nonce + 1;

--- a/contracts/Permissions/IRoleManager.sol
+++ b/contracts/Permissions/IRoleManager.sol
@@ -40,4 +40,11 @@ interface IRoleManager {
         external
         view
         returns (bool);
+
+    /// @dev Determines if the specified address has permission to update sigNonces
+    /// @param potentialAddress Address to check
+    function isSigNonceUpdater(address potentialAddress)
+        external
+        view
+        returns (bool);
 }

--- a/contracts/Permissions/RoleManager.sol
+++ b/contracts/Permissions/RoleManager.sol
@@ -14,7 +14,7 @@ import "./RoleManagerStorage.sol";
 contract RoleManager is
     IRoleManager,
     AccessControlUpgradeable,
-    RoleManagerStorageV1
+    RoleManagerStorageV2
 {
     /// @dev initializer to call after deployment, can only be called once
     function initialize(address protocolAdmin) public initializer {
@@ -77,5 +77,15 @@ contract RoleManager is
         returns (bool)
     {
         return hasRole(CURATOR_TOKEN_ADMIN, potentialAddress);
+    }
+
+    /// @dev Determines if the specified address has permission to update sigNonces
+    /// @param potentialAddress Address to check
+    function isSigNonceUpdater(address potentialAddress)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(SIG_NONCE_UPDATER, potentialAddress);
     }
 }

--- a/contracts/Permissions/RoleManagerStorage.sol
+++ b/contracts/Permissions/RoleManagerStorage.sol
@@ -30,8 +30,14 @@ contract RoleManagerStorageV1 {
 
 /// On the next version of the protocol, if new variables are added, put them in the below
 /// contract and use this as the inheritance chain.
-/**
 contract RoleManagerStorageV2 is RoleManagerStorageV1 {
+    bytes32 public constant SIG_NONCE_UPDATER = keccak256("SIG_NONCE_UPDATER");
+}
+
+/// On the next version of the protocol, if new variables are added, put them in the below
+/// contract and use this as the inheritance chain.
+/**
+contract RoleManagerStorageV3 is RoleManagerStorageV2 {
   address newVariable;
 }
  */

--- a/deploy/mumbai/upgrade-v2.ts
+++ b/deploy/mumbai/upgrade-v2.ts
@@ -1,0 +1,160 @@
+import {HardhatRuntimeEnvironment} from "hardhat/types";
+import {ethers, upgrades} from "hardhat";
+
+import {deployProxyContract} from "../../deploy_config/protocol";
+import config from "../../deploy_config/mumbai";
+
+const deployConfig = require("../../deploy_data/hardhat_contracts.json");
+
+// Deploy the protocol on the L2
+// For Mumbai testnet, we will deploy test token contracts as well as the full protocol contracts
+// You must set DEPLOY_PRIVATE_KEY which is shared in RaRa 1Password
+// Run: npx hardhat deploy --network mumbai --tags mumbai-upgrade-v2 --export-all ./deploy_data/hardhat_contracts.json
+module.exports = async (hre: HardhatRuntimeEnvironment) => {
+  const {getNamedAccounts} = hre;
+  const {deployer} = await getNamedAccounts();
+  console.log("\n\nDeploying with account " + deployer);
+
+  const chainId = "80001"; // mumbai
+  const chainRPC = process.env.DATA_TESTING_RPC;
+  const deployerPK: any = process.env.DEPLOY_PRIVATE_KEY;
+  const provider = new ethers.providers.JsonRpcProvider(chainRPC);
+  const signer = new ethers.utils.SigningKey(deployerPK);
+  let wallet = new ethers.Wallet(signer);
+  wallet = wallet.connect(provider);
+  console.log({chainId, rpc: chainRPC, wallet: wallet.address});
+
+  //
+  // Upgrade Existing Contracts
+  //
+  console.log("\n\nUpgrading existing contracts");
+  const DefaultProxyAdmin = new ethers.Contract(
+    deployConfig[chainId][0].contracts.DefaultProxyAdmin.address,
+    deployConfig[chainId][0].contracts.DefaultProxyAdmin.abi,
+    wallet
+  );
+
+  // Update implementation for AddressManager
+  const roleManagerAddress =
+    deployConfig[chainId][0].contracts.RoleManager.address;
+  // console.log({roleManagerAddress});
+  let addressManager = await deployProxyContract(hre, "AddressManager", [
+    roleManagerAddress,
+  ]);
+  let txn = await DefaultProxyAdmin.upgrade(
+    addressManager.address,
+    addressManager.implementation
+  );
+  await txn.wait();
+  let implementation = await DefaultProxyAdmin.getProxyImplementation(
+    addressManager.address
+  );
+  console.log({
+    name: "AddressManager",
+    address: addressManager.address,
+    imp: addressManager.implementation,
+    proxy_imp: implementation,
+  });
+  const addressManagerAddress = addressManager.address;
+
+  // Update implementation for ParameterManager
+  let pm = await deployProxyContract(hre, "ParameterManager", [
+    addressManagerAddress,
+  ]);
+  txn = await DefaultProxyAdmin.upgrade(pm.address, pm.implementation);
+  await txn.wait();
+  implementation = await DefaultProxyAdmin.getProxyImplementation(pm.address);
+  console.log({
+    name: "ParameterManager",
+    address: pm.address,
+    imp: pm.implementation,
+    proxy_imp: implementation,
+  });
+
+  // Update implementation for MakerRegistrar
+  let mr = await deployProxyContract(hre, "MakerRegistrar", [
+    addressManagerAddress,
+  ]);
+  txn = await DefaultProxyAdmin.upgrade(mr.address, mr.implementation);
+  await txn.wait();
+  implementation = await DefaultProxyAdmin.getProxyImplementation(mr.address);
+  console.log({
+    name: "MakerRegistrar",
+    address: mr.address,
+    imp: mr.implementation,
+    proxy_imp: implementation,
+  });
+
+  // Update implementation for ReactionVault
+  const rv = await deployProxyContract(hre, "ReactionVault", [
+    addressManagerAddress,
+  ]);
+  txn = await DefaultProxyAdmin.upgrade(rv.address, rv.implementation);
+  await txn.wait();
+  implementation = await DefaultProxyAdmin.getProxyImplementation(rv.address);
+  console.log({
+    name: "ReactionVault",
+    address: rv.address,
+    imp: rv.implementation,
+    proxy_imp: implementation,
+  });
+
+  //
+  // Deploy new contracts
+  //
+  console.log("\n\nDeploying new contracts");
+
+  // Deploy DispatcherManager
+  const DispatcherManagerFactory = await ethers.getContractFactory(
+    "DispatcherManager"
+  );
+  const deployedDispatcherManager = await upgrades.deployProxy(
+    DispatcherManagerFactory,
+    [addressManagerAddress]
+  );
+  const dispatcherManager = DispatcherManagerFactory.attach(
+    deployedDispatcherManager.address
+  );
+
+  //
+  // Temporarily grant roles to the deploying account
+  //
+  console.log("\n\nGranting temp permissions");
+  const roleManager = await ethers.getContractAt(
+    "RoleManager",
+    roleManagerAddress
+  );
+  await roleManager.grantRole(
+    await roleManager.ADDRESS_MANAGER_ADMIN(),
+    deployer,
+    {gasLimit: "200000"}
+  );
+  console.log("Granted ADDRESS_MANAGER_ADMIN to " + deployer);
+
+  //
+  // Updating AddressManager
+  //
+  console.log("\n\nUpdating AddressManager");
+  const _addressManager = await ethers.getContractAt(
+    "AddressManager",
+    addressManager.address
+  );
+  await _addressManager.setDispatcherManager(dispatcherManager.address, {
+    gasLimit: "200000",
+  });
+
+  //
+  // Remove the temporary permissions for the deploy account
+  //
+  console.log("\n\nRevoking temp permissions for deployer");
+  await roleManager.revokeRole(
+    await roleManager.ADDRESS_MANAGER_ADMIN(),
+    deployer,
+    {gasLimit: "200000"}
+  );
+  console.log("Revoked ADDRESS_MANAGER_ADMIN to " + deployer);
+
+  console.log("\n\nDone.");
+};
+
+module.exports.tags = ["mumbai-upgrade-v2"];

--- a/test/Parameters/ParameterManager.ts
+++ b/test/Parameters/ParameterManager.ts
@@ -278,4 +278,12 @@ describe("ParameterManager", function () {
       parameterManager.connect(ALICE).setFreeReactionLimit(100)
     ).to.be.revertedWith(NOT_ADMIN);
   });
+  it("Should not allow an uncredentialed address to increment sigNonces", async () => {
+    const [OWNER, ALICE] = await ethers.getSigners();
+    const {parameterManager} = await deploySystem(OWNER);
+
+    await expect(
+      parameterManager.connect(OWNER).incSigNonceFor(ALICE.address)
+    ).to.be.revertedWith("Not signature nonce updater");
+  });
 });

--- a/test/Scripts/setup.ts
+++ b/test/Scripts/setup.ts
@@ -207,6 +207,11 @@ const deploySystem = async (owner: SignerWithAddress) => {
     await roleManager.CURATOR_VAULT_PURCHASER(),
     reactionVault.address
   );
+  // Reaction Vault can update sigNonces
+  await roleManager.grantRole(
+    await roleManager.SIG_NONCE_UPDATER(),
+    reactionVault.address
+  );
   // Curator Vault can mint/burn curator token
   await roleManager.grantRole(
     await roleManager.CURATOR_TOKEN_ADMIN(),
@@ -216,6 +221,11 @@ const deploySystem = async (owner: SignerWithAddress) => {
   await roleManager.grantRole(
     await roleManager.CURATOR_TOKEN_ADMIN(),
     curatorVault2.address
+  );
+  // Maker Registrar can update sigNonces
+  await roleManager.grantRole(
+    await roleManager.SIG_NONCE_UPDATER(),
+    makerRegistrar.address
   );
 
   // Update address manager


### PR DESCRIPTION
Created new role `SIG_NONCE_UPDATER`

Guarded the `ParameterManager#incSigNonceFor()` method with this role

During protocol upgrade...
1. Update RoleManager implementation
2. Assign `SIG_NONCE_UPDATER` role to contracts `MakerRegistrar` and `ReactionVault`